### PR TITLE
Fix make target manuals with set ROOTFS

### DIFF
--- a/ether/Makefile
+++ b/ether/Makefile
@@ -30,6 +30,7 @@ library:
 	install -m ${DIR_PERM} -o ${OWNER} -g ${GROUP} -d ${BIN}
 scripts:
 manuals:
+	test -d ${MAN} || install -m ${DIR_PERM} -o ${OWNER} -g ${GROUP} -d ${MAN}
 	install -m ${MAN_PERM} -o ${OWNER} -g ${GROUP} ${PAGES} ${MAN}
 install: $(TOOLS) library
 	install -m ${SUID_PERM} -o ${OWNER} -g ${GROUP} ${TOOLS} ${BIN}

--- a/key/Makefile
+++ b/key/Makefile
@@ -31,6 +31,7 @@ library:
 	install -m ${DIR_PERM} -o ${OWNER} -g ${GROUP} -d ${BIN}
 scripts:
 manuals:
+	test -d ${MAN} || install -m ${DIR_PERM} -o ${OWNER} -g ${GROUP} -d ${MAN}
 	install -m ${MAN_PERM} -o ${OWNER} -g ${GROUP} ${PAGES} ${MAN}
 install: $(TOOLS)
 	install -m ${BIN_PERM} -o ${OWNER} -g ${GROUP} ${TOOLS} ${BIN}

--- a/mdio/Makefile
+++ b/mdio/Makefile
@@ -30,6 +30,7 @@ library:
 	install -m ${DIR_PERM} -o ${OWNER} -g ${GROUP} -d ${BIN}
 scripts:
 manuals:
+	test -d ${MAN} || install -m ${DIR_PERM} -o ${OWNER} -g ${GROUP} -d ${MAN}
 	install -m ${MAN_PERM} -o ${OWNER} -g ${GROUP} ${PAGES} ${MAN}
 install: $(TOOLS) library
 	install -m ${SUID_PERM} -o ${OWNER} -g ${GROUP} ${TOOLS} ${BIN}

--- a/mme/Makefile
+++ b/mme/Makefile
@@ -30,6 +30,7 @@ library:
 	install -m ${DIR_PERM} -o ${OWNER} -g ${GROUP} -d ${BIN}
 scripts:
 manuals:
+	test -d ${MAN} || install -m ${DIR_PERM} -o ${OWNER} -g ${GROUP} -d ${MAN}
 	install -m ${MAN_PERM} -o ${OWNER} -g ${GROUP} ${PAGES} ${MAN}
 install: $(TOOLS) library
 	install -m ${BIN_PERM} -o ${OWNER} -g ${GROUP} ${TOOLS} ${BIN}

--- a/nvm/Makefile
+++ b/nvm/Makefile
@@ -28,6 +28,7 @@ compact: compile
 	if [ -x /usr/local/bin/upx ]; then upx --best ${TOOLS}; fi
 scripts:
 manuals:
+	test -d ${MAN} || install -m ${DIR_PERM} -o ${OWNER} -g ${GROUP} -d ${MAN}
 	install -m ${MAN_PERM} -o ${OWNER} -g ${GROUP} ${PAGES} ${MAN}
 library:
 	install -m ${DIR_PERM} -o ${OWNER} -g ${GROUP} -d ${BIN}

--- a/pib/Makefile
+++ b/pib/Makefile
@@ -30,6 +30,7 @@ compact: compile
 	if [ -x /usr/local/bin/upx ]; then upx --best ${TOOLS}; fi
 scripts:
 manuals:
+	test -d ${MAN} || install -m ${DIR_PERM} -o ${OWNER} -g ${GROUP} -d ${MAN}
 	install -m ${MAN_PERM} -o ${OWNER} -g ${GROUP} ${PAGES} ${MAN}
 library:
 	install -m ${DIR_PERM} -o ${OWNER} -g ${GROUP} -d ${BIN}

--- a/plc/Makefile
+++ b/plc/Makefile
@@ -35,6 +35,7 @@ library:
 	install -m ${DIR_PERM} -o ${OWNER} -g ${GROUP} -d ${BIN}
 scripts:
 manuals:
+	test -d ${MAN} || install -m ${DIR_PERM} -o ${OWNER} -g ${GROUP} -d ${MAN}
 	install -m ${MAN_PERM} -o ${OWNER} -g ${GROUP} ${PAGES} ${MAN}
 install: $(TOOLS) library
 	install -m ${SUID_PERM} -o ${OWNER} -g ${GROUP} ${TOOLS} ${BIN}

--- a/ram/Makefile
+++ b/ram/Makefile
@@ -30,6 +30,7 @@ library:
 	install -m ${DIR_PERM} -o ${OWNER} -g ${GROUP} -d ${BIN}
 scripts:
 manuals:
+	test -d ${MAN} || install -m ${DIR_PERM} -o ${OWNER} -g ${GROUP} -d ${MAN}
 	install -m ${MAN_PERM} -o ${OWNER} -g ${GROUP} ${PAGES} ${MAN}
 install: $(TOOLS) library
 	install -m ${BIN_PERM} -o ${OWNER} -g ${GROUP} ${TOOLS} ${BIN}

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -30,6 +30,7 @@ all compile:
 install:
 scripts:
 manuals:
+	test -d ${MAN} || install -m ${DIR_PERM} -o ${OWNER} -g ${GROUP} -d ${MAN}
 	install -m ${MAN_PERM} -o ${OWNER} -g ${GROUP} ${PAGES} ${MAN}
 library:
 uninstall:

--- a/serial/Makefile
+++ b/serial/Makefile
@@ -30,6 +30,7 @@ library:
 	install -m ${DIR_PERM} -o ${OWNER} -g ${GROUP} -d ${BIN}
 scripts:
 manuals:
+	test -d ${MAN} || install -m ${DIR_PERM} -o ${OWNER} -g ${GROUP} -d ${MAN}
 	install -m ${MAN_PERM} -o ${OWNER} -g ${GROUP} ${PAGES} ${MAN}
 install: $(TOOLS) library
 	install -m ${BIN_PERM} -o ${OWNER} -g ${GROUP} ${TOOLS} ${BIN}


### PR DESCRIPTION
In the case "make manuals" with set $ROOTFS is called and the target directory doesn't exist, the makefile abort with an error.

This bugfix checks the target directory and create it if necessary

Signed-off-by: Stefan Wahren stefan.wahren@i2se.com
