### PR TITLE
QCA7000 support for pskey

### DIFF
--- a/pib/Makefile
+++ b/pib/Makefile
@@ -70,7 +70,7 @@ setpib: setpib.o getoptv.o putoptv.o version.o hexpeek.o hexdump.o dataspec.o ba
 setpib1: setpib1.o getoptv.o putoptv.o version.o hexpeek.o hexdump.o dataspec.o basespec.o error.o todigit.o uintspec.o bytespec.o pibfile1.o checksum32.o fdchecksum32.o memencode.o
 setpib2: setpib2.o getoptv.o putoptv.o version.o hexpeek.o hexdump.o dataspec.o basespec.o error.o todigit.o uintspec.o bytespec.o pibfile1.o checksum32.o fdchecksum32.o memencode.o
 psin: psin.o getoptv.o putoptv.o version.o hexdecode.o hexstring.o todigit.o error.o pibfile1.o piblock.o pibscalers.o fdchecksum32.o 
-pskey: pskey.o getoptv.o putoptv.o version.o error.o hexdecode.o hexstring.o hexout.o pibfile1.o SHA256Reset.o SHA256Write.o SHA256Block.o SHA256Fetch.o keys.o fdchecksum32.o
+pskey: pskey.o getoptv.o putoptv.o version.o error.o hexdecode.o hexstring.o hexout.o pibfile.o pibfile1.o pibfile2.o pibscalers.o SHA256Reset.o SHA256Write.o SHA256Block.o SHA256Fetch.o keys.o checksum32.o fdchecksum32.o
 psout: psout.o getoptv.o putoptv.o version.o error.o pibfile.o pibfile1.o pibfile2.o pibscalers.o checksum32.o fdchecksum32.o
 psnotch: psnotch.o getoptv.o putoptv.o version.o error.o todigit.o uintspec.o
 psgraph: psgraph.o getoptv.o putoptv.o version.o error.o todigit.o uintspec.o pibscalers.o

--- a/pib/pskey.c
+++ b/pib/pskey.c
@@ -179,7 +179,7 @@ int main (int argc, char const * argv [])
 		(char const *) (0)
 	};
 	struct _file_ pib;
-	uint8_t buffer [INT_PRESCALER_LENGTH];
+	uint8_t buffer [AMP_PRESCALER_LENGTH];
 	signed state = 0;
 	flag_t flags = (flag_t) (0);
 	signed c;

--- a/pib/pskey.c
+++ b/pib/pskey.c
@@ -45,8 +45,8 @@
  *
  *
  *   Contributor(s):
- *	    Charles Maier <cmaier@qca.qualcomm.com>
- *      Stefan Wahren <stefan.wahren@i2se.com>
+ *	Charles Maier <cmaier@qca.qualcomm.com>
+ *	Stefan Wahren <stefan.wahren@i2se.com>
  *
  *--------------------------------------------------------------------*/
 


### PR DESCRIPTION
Until now pskey only supports PIB files from int6000 chipset. With these patches pskey should the same chipsets as psout (incl. QCA7000). The patches are tested only against QCA7000 PIB file.
