### PR TITLE
Fix amphost PIB read error

### DIFF
--- a/plc/WriteExecutePIB.c
+++ b/plc/WriteExecutePIB.c
@@ -119,7 +119,7 @@ signed WriteExecutePIB (struct plc * plc, uint32_t offset, struct pib_header * h
 #endif
 
 	uint32_t length = PLC_MODULE_SIZE;
-	uint32_t extent = LE32TOH (header->PIBLENGTH);
+	uint32_t extent = LE16TOH (header->PIBLENGTH);
 	Request (plc, "Write %s (0) (%08X:%d)", plc->PIB.name, offset, extent);
 	while (extent)
 	{


### PR DESCRIPTION
Fix wrong little endian conversion of 16 bit header->PIBLENGTH

amphost terminated with error on a device reset:

root@OpenWrt:/lib/firmware/plc# plctool -i br-lan -R
br-lan 00:B0:52:00:00:01 Reset Device
br-lan BC:F2:AF:ED:36:46 Resetting ...
root@OpenWrt:/lib/firmware/plc# 
br-lan 00:B0:52:00:00:01 Host Action Request is (4) config memory.
br-lan 00:B0:52:00:00:01 Write /lib/firmware/plc/FW0153_FW_V1_MAC-7450-v5.3.1-02-NW6__-X-FINAL.nvm (0) (00000040:18912)
br-lan 00:B0:52:00:00:01 Start /lib/firmware/plc/FW0153_FW_V1_MAC-7450-v5.3.1-02-NW6__-X-FINAL.nvm (0) (000000C0)
br-lan 00:B0:52:00:00:01 Host Action Request is (0) start device.
br-lan 00:B0:52:00:00:01 Write /lib/firmware/plc/user.pib.old (0) (00200000:1077411840)
amphost: WriteExecutePIB can't read /lib/firmware/plc/user.pib.old

with this fix applied:

root@OpenWrt:/lib/firmware/plc# plctool -i br-lan -R
br-lan 00:B0:52:00:00:01 Reset Device
br-lan BC:F2:AF:ED:36:46 Resetting ...
root@OpenWrt:/lib/firmware/plc# 
br-lan 00:B0:52:00:00:01 Host Action Request is (4) config memory.
br-lan 00:B0:52:00:00:01 Write /lib/firmware/plc/FW0153_FW_V1_MAC-7450-v5.3.1-02-NW6__-X-FINAL.nvm (0) (00000040:18912)
br-lan 00:B0:52:00:00:01 Start /lib/firmware/plc/FW0153_FW_V1_MAC-7450-v5.3.1-02-NW6__-X-FINAL.nvm (0) (000000C0)
br-lan 00:B0:52:00:00:01 Host Action Request is (0) start device.
br-lan 00:B0:52:00:00:01 Write /lib/firmware/plc/user.pib.old (0) (00200000:16440)
br-lan 00:B0:52:00:00:01 Write /lib/firmware/plc/FW0153_FW_V1_MAC-7450-v5.3.1-02-NW6__-X-FINAL.nvm (3) (00357E40:444516)
br-lan 00:B0:52:00:00:01 Start /lib/firmware/plc/FW0153_FW_V1_MAC-7450-v5.3.1-02-NW6__-X-FINAL.nvm (3) (00358734)
br-lan BC:F2:AF:ED:36:46 INT7400-MAC-5-3-5317-02-1554-20130919-FINAL-D is running