### PR TITLE
Fix issue #49 - unable to flash firmware into QCA7000 with plcboot

### DIFF
--- a/plc/plcboot.c
+++ b/plc/plcboot.c
@@ -288,13 +288,13 @@ int main (int argc, char const * argv [])
 			{
 				error (1, EINVAL, "%s", optarg);
 			}
-			if ((plc.CFG.file = open (plc.CFG.name = optarg, O_BINARY|O_RDONLY)) == -1)
+			if ((plc.SFT.file = open (plc.SFT.name = optarg, O_BINARY|O_RDONLY)) == -1)
 			{
-				error (1, errno, "%s", plc.CFG.name);
+				error (1, errno, "%s", plc.SFT.name);
 			}
-			if (nvmfile2 (&plc.CFG))
+			if (nvmfile2 (&plc.SFT))
 			{
-				error (1, errno, "Bad softloader file: %s", plc.CFG.name);
+				error (1, errno, "Bad softloader file: %s", plc.SFT.name);
 			}
 			break;
 		case 't':
@@ -345,7 +345,7 @@ int main (int argc, char const * argv [])
 	{
 		error (1, ECANCELED, "No Firmware file named");
 	}
-	if (plc.CFG.file == -1)
+	if (plc.SFT.file == -1)
 	{
 		if (_anyset (plc.flags, PLC_FLASH_DEVICE))
 		{

--- a/plc/plchost.c
+++ b/plc/plchost.c
@@ -508,13 +508,13 @@ int main (int argc, char const * argv [])
 			{
 				error (1, EINVAL, "%s", optarg);
 			}
-			if ((plc.CFG.file = open (plc.CFG.name = optarg, O_BINARY|O_RDONLY)) == -1)
+			if ((plc.SFT.file = open (plc.SFT.name = optarg, O_BINARY|O_RDONLY)) == -1)
 			{
-				error (1, errno, "%s", plc.CFG.name);
+				error (1, errno, "%s", plc.SFT.name);
 			}
-			if (nvmfile2 (&plc.CFG))
+			if (nvmfile2 (&plc.SFT))
 			{
-				error (1, errno, "Bad firmware file: %s", plc.CFG.name);
+				error (1, errno, "Bad firmware file: %s", plc.SFT.name);
 			}
 			break;
 		case 't':
@@ -548,7 +548,7 @@ int main (int argc, char const * argv [])
 	{
 		error (1, ECANCELED, "No host PIB file named");
 	}
-	if (plc.CFG.file == -1)
+	if (plc.SFT.file == -1)
 	{
 		if (_anyset (plc.flags, PLC_FLASH_DEVICE))
 		{

--- a/plc/plchostd.c
+++ b/plc/plchostd.c
@@ -625,13 +625,13 @@ int main (int argc, char const * argv [])
 			{
 				error (1, EINVAL, "%s", optarg);
 			}
-			if ((plc.CFG.file = open (plc.CFG.name = optarg, O_BINARY|O_RDONLY)) == -1)
+			if ((plc.SFT.file = open (plc.SFT.name = optarg, O_BINARY|O_RDONLY)) == -1)
 			{
-				error (1, errno, "%s", plc.CFG.name);
+				error (1, errno, "%s", plc.SFT.name);
 			}
-			if (nvmfile (&plc.CFG))
+			if (nvmfile (&plc.SFT))
 			{
-				error (1, errno, "Bad firmware file: %s", plc.CFG.name);
+				error (1, errno, "Bad firmware file: %s", plc.SFT.name);
 			}
 			_setbits (plc.flags, PLC_FLASH_DEVICE);
 			break;
@@ -674,7 +674,7 @@ int main (int argc, char const * argv [])
 	{
 		error (1, ECANCELED, "No user PIB file named");
 	}
-	if (plc.CFG.file == -1)
+	if (plc.SFT.file == -1)
 	{
 		if (_anyset (plc.flags, PLC_FLASH_DEVICE))
 		{

--- a/plc/plchostd2.c
+++ b/plc/plchostd2.c
@@ -624,13 +624,13 @@ int main (int argc, char const * argv [])
 			{
 				error (1, EINVAL, "%s", optarg);
 			}
-			if ((plc.CFG.file = open (plc.CFG.name = optarg, O_BINARY|O_RDONLY)) == -1)
+			if ((plc.SFT.file = open (plc.SFT.name = optarg, O_BINARY|O_RDONLY)) == -1)
 			{
-				error (1, errno, "%s", plc.CFG.name);
+				error (1, errno, "%s", plc.SFT.name);
 			}
-			if (nvmfile2 (&plc.CFG))
+			if (nvmfile2 (&plc.SFT))
 			{
-				error (1, errno, "Bad firmware file: %s", plc.CFG.name);
+				error (1, errno, "Bad firmware file: %s", plc.SFT.name);
 			}
 			break;
 		case 't':
@@ -664,7 +664,7 @@ int main (int argc, char const * argv [])
 	{
 		error (1, ECANCELED, "No host PIB file named");
 	}
-	if (plc.CFG.file == -1)
+	if (plc.SFT.file == -1)
 	{
 		if (_anyset (plc.flags, PLC_FLASH_DEVICE))
 		{

--- a/plc/plctool.c
+++ b/plc/plctool.c
@@ -593,13 +593,13 @@ int main (int argc, char const * argv [])
 			{
 				error (1, EINVAL, "%s", optarg);
 			}
-			if ((plc.CFG.file = open (plc.CFG.name = optarg, O_BINARY|O_RDONLY)) == -1)
+			if ((plc.SFT.file = open (plc.SFT.name = optarg, O_BINARY|O_RDONLY)) == -1)
 			{
-				error (1, errno, "%s", plc.CFG.name);
+				error (1, errno, "%s", plc.SFT.name);
 			}
-			if (nvmfile2 (&plc.CFG))
+			if (nvmfile2 (&plc.SFT))
 			{
-				error (1, errno, "Bad softloader file: %s", plc.CFG.name);
+				error (1, errno, "Bad softloader file: %s", plc.SFT.name);
 			}
 			_setbits (plc.flags, PLC_FLASH_DEVICE);
 			break;


### PR DESCRIPTION
This patch should fix the failure (issue #49) during flash firmware into the QCA7000 with plcboot.