### PR TITLE
open-plc-utils: fix musl and fortify source compatibility

### DIFF
--- a/ether/readpacket.c
+++ b/ether/readpacket.c
@@ -70,6 +70,10 @@
 #include <memory.h>
 #include <errno.h>
 
+#if defined (__linux__)
+#include <poll.h>
+#endif
+
 #include "../ether/channel.h"
 #include "../tools/memory.h"
 #include "../tools/error.h"
@@ -94,8 +98,6 @@ ssize_t readpacket (struct channel const * channel, void * memory, ssize_t exten
 	return (extent);
 
 #elif defined (__linux__)
-
-#include <sys/poll.h>
 
 	struct pollfd pollfd =
 	{

--- a/serial/serial.c
+++ b/serial/serial.c
@@ -69,6 +69,8 @@
 
 #if defined (WIN32)
 #include <Windows.h>
+#else
+#include <sys/select.h>
 #endif
 
 /*====================================================================*


### PR DESCRIPTION
- Include `poll.h` at the top of `ether/readpacket.c` to avoid nested
  declaration errors caused by fortify source headers
- Add missing `sys/select.h` include to `serial/serial.c`

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>