### PR TITLE
Improve modpib to show security level explicit

### DIFF
--- a/pib/pibpeek1.c
+++ b/pib/pibpeek1.c
@@ -209,6 +209,7 @@ signed pibpeek1 (void const * memory)
 		}
 		printf ("\n");
 		printf ("\tNID %s\n", hexstring (buffer, sizeof (buffer), PIB->LocalDeviceConfig.PreferredNID, sizeof (PIB->LocalDeviceConfig.PreferredNID)));
+		printf ("\tSecurity level %u\n", (PIB->LocalDeviceConfig.PreferredNID[HPAVKEY_NID_LEN-1] >> 4) & 3);
 		printf ("\tNET %s\n", PIB->LocalDeviceConfig.NET);
 		printf ("\tMFG %s\n", PIB->LocalDeviceConfig.MFG);
 		printf ("\tUSR %s\n", PIB->LocalDeviceConfig.USR);
@@ -240,6 +241,7 @@ signed pibpeek1 (void const * memory)
 		}
 		printf ("\n");
 		printf ("\tNID %s\n", hexstring (buffer, sizeof (buffer), PIB->LocalDeviceConfig.PreferredNID, sizeof (PIB->LocalDeviceConfig.PreferredNID)));
+		printf ("\tSecurity level %u\n", (PIB->LocalDeviceConfig.PreferredNID[HPAVKEY_NID_LEN-1] >> 4) & 3);
 		printf ("\tNET %s\n", PIB->LocalDeviceConfig.NET);
 		printf ("\tMFG %s\n", PIB->LocalDeviceConfig.MFG);
 		printf ("\tUSR %s\n", PIB->LocalDeviceConfig.USR);

--- a/pib/pibpeek2.c
+++ b/pib/pibpeek2.c
@@ -115,6 +115,7 @@ signed pibpeek2 (void const * memory)
 	}
 	printf ("\n");
 	printf ("\tNID %s\n", hexstring (buffer, sizeof (buffer), PIB->LocalDeviceConfig.PreferredNID, sizeof (PIB->LocalDeviceConfig.PreferredNID)));
+	printf ("\tSecurity level %u\n", (PIB->LocalDeviceConfig.PreferredNID[HPAVKEY_NID_LEN-1] >> 4) & 3);
 	printf ("\tNET %s\n", PIB->LocalDeviceConfig.NET);
 	printf ("\tMFG %s\n", PIB->LocalDeviceConfig.MFG);
 	printf ("\tUSR %s\n", PIB->LocalDeviceConfig.USR);


### PR DESCRIPTION
This pull request improves modpib to explicitly show the security level:

```
$ ./modpib -v parameters.pib 
PIB 0-0 0 bytes
MAC CC:00:FF:FF:EE:EE
DAK 68:9F:07:4B:8B:02:75:A2:71:0B:0B:57:79:AD:16:30 (HomePlugAV)
NMK 50:D3:E4:93:3F:85:5B:70:40:78:4D:F8:15:AA:8D:B7 (HomePlugAV)
NID B0:F2:E6:95:66:6B:03
Security level 0
NET Qualcomm Atheros Enabled Network
MFG Qualcomm Atheros HomePlug AV Device
USR Qualcomm Atheros Enabled Product
CCo Auto
MDU N/A
```
