### PR TITLE
Portability - add NetBSD support

### DIFF
--- a/README
+++ b/README
@@ -65,6 +65,8 @@ We recommend that you open file docbook/index.html with a web browser
 the read Chapter 1 before attempting to install or use the toolkit 
 but the impatient may do the following and survive ...
 
+Note: 'make' is assumed to be the Gnu make command.
+
 TO INSTALL
 ----------
 

--- a/ether/channel.c
+++ b/ether/channel.c
@@ -89,7 +89,7 @@ struct channel channel =
 
 #if defined (__linux__)
 
-#elif defined (__APPLE__) || defined (__OpenBSD__)
+#elif defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__)
 
 	(struct bpf *) (0),
 

--- a/ether/channel.h
+++ b/ether/channel.h
@@ -76,7 +76,7 @@
  *   sort out the raw socket mess;
  *--------------------------------------------------------------------*/
 
-#if defined (__linux__) || defined (__APPLE__) || defined (__OpenBSD__)
+#if defined (__linux__) || defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__)
 #       ifdef WINPCAP
 #               error "Don't enable winpcap on Linux. It won't work."
 #               endif
@@ -117,7 +117,7 @@
 #elif defined (__APPLE__)
 #       define CHANNEL_ETHDEVICE "en0"
 #       define CHANNEL_BPFDEVICE "/dev/bpf%d"
-#elif defined (__OpenBSD__)
+#elif defined (__OpenBSD__) || defined(__NetBSD__)
 #       define CHANNEL_ETHDEVICE "bce0"
 #       define CHANNEL_BPFDEVICE "/dev/bpf%d"
 #else
@@ -168,7 +168,7 @@ typedef struct channel
 
 #if defined (__linux__)
 
-#elif defined (__APPLE__) || defined (__OpenBSD__)
+#elif defined (__APPLE__) || defined (__OpenBSD__) || defined(__NetBSD__)
 
 	struct bpf
 	{

--- a/ether/closechannel.c
+++ b/ether/closechannel.c
@@ -70,7 +70,7 @@ signed closechannel (struct channel const * channel)
 
 	return (close (channel->fd));
 
-#elif defined (__APPLE__) || (__OpenBSD__)
+#elif defined (__APPLE__) || (__OpenBSD__) || defined (__NetBSD__)
 
 	free (channel->bpf->bpf_buffer);
 	free (channel->bpf);

--- a/ether/ether.h
+++ b/ether/ether.h
@@ -30,7 +30,7 @@
 #       include <net/ethernet.h>
 #       include <arpa/inet.h>
 #       include <net/bpf.h>
-#elif defined (__OpenBSD__)
+#elif defined (__OpenBSD__) || defined (__NetBSD__)
 #       include <sys/ioctl.h>
 #       include <sys/types.h>
 #       include <sys/socket.h>

--- a/ether/gethwaddr.c
+++ b/ether/gethwaddr.c
@@ -158,7 +158,7 @@ int gethwaddr (void * memory, char const * device)
 	}
 	freeifaddrs (ifaddrs);
 
-#elif defined (__OpenBSD__)
+#elif defined (__OpenBSD__) || defined(__NetBSD__)
 
 #include <ifaddrs.h>
 #include <net/if_dl.h>

--- a/ether/getifname.c
+++ b/ether/getifname.c
@@ -74,7 +74,7 @@ char * getifname (signed index)
 
 #if defined (__linux__)
 
-#elif defined (__APPLE__) || defined (__OpenBSD__)
+#elif defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__)
 
 #elif defined (WINPCAP) || defined (LIBPCAP)
 

--- a/ether/hostnics.c
+++ b/ether/hostnics.c
@@ -69,7 +69,7 @@
 #	include <net/if.h>
 #	include <netpacket/packet.h>
 #	include <ifaddrs.h>
-#elif defined (__APPLE__) || defined (__OpenBSD__)
+#elif defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__)
 #	include <sys/types.h>
 #	include <sys/socket.h>
 #	include <net/if.h>
@@ -146,7 +146,7 @@ unsigned hostnics (struct nic nics [], unsigned size)
 	}
 	close (fd);
 
-#elif defined (__linux__) || defined (__APPLE__) || defined (__OpenBSD__)
+#elif defined (__linux__) || defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__)
 
 /*
  *	generic (POSIX) method for unix-like systems;
@@ -195,7 +195,7 @@ unsigned hostnics (struct nic nics [], unsigned size)
 				memcpy (nic->ethernet, LLADDR (sockaddr_ll), sizeof (nic->ethernet));
 			}
 
-#elif defined (__APPLE__) || defined (__OpenBSD__)
+#elif defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__)
 
 			if (ifaddr->ifa_addr->sa_family == AF_LINK)
 			{

--- a/ether/openchannel.c
+++ b/ether/openchannel.c
@@ -70,7 +70,7 @@
 #	include <sys/stat.h>
 #	include <fcntl.h>
 #	include <stdlib.h>
-#elif defined (__OpenBSD__)
+#elif defined (__OpenBSD__) || defined (__NetBSD__)
 #	include <sys/ioctl.h>
 #	include <sys/stat.h>
 #	include <sys/types.h>
@@ -87,7 +87,7 @@
 #include "../tools/flags.h"
 #include "../tools/error.h"
 
-#if defined (__APPLE__) || defined (__OpenBSD__)
+#if defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__)
 #	include "../ether/gethwaddr.c"
 #endif
 
@@ -296,7 +296,7 @@ signed openchannel (struct channel * channel)
 		}
 	};
 
-#if defined (__APPLE__) || defined (__OpenBSD__)
+#if defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__)
 
 	struct ifreq ifreq;
 	struct timeval timeval;
@@ -351,7 +351,7 @@ signed openchannel (struct channel * channel)
 		error (1, errno, "Can't allocate receive buffer");
 	}
 
-#if defined (__APPLE__)
+#if defined (__APPLE__) || defined (__NetBSD__)
 
 	state = 0;
 	if (ioctl (channel->fd, BIOCSSEESENT, &state) == -1)

--- a/ether/pcapdevs.c
+++ b/ether/pcapdevs.c
@@ -62,7 +62,7 @@
 
 #if defined (__linux__)
 #elif defined (__APPLE__)
-#elif defined (__OpenBSD__)
+#elif defined (__OpenBSD__) || defined (__NetBSD__)
 #	include <sys/types.h>
 #	include <sys/socket.h>
 #	include <net/if.h>

--- a/ether/readpacket.c
+++ b/ether/readpacket.c
@@ -131,7 +131,7 @@ ssize_t readpacket (struct channel const * channel, void * memory, ssize_t exten
 		}
 	}
 
-#elif defined (__APPLE__) || defined (__OpenBSD__)
+#elif defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__)
 
 	struct bpf_hdr * bpf_packet;
 	struct bpf * bpf = channel->bpf;;

--- a/ether/sendpacket.c
+++ b/ether/sendpacket.c
@@ -77,7 +77,7 @@ ssize_t sendpacket (struct channel const * channel, void * memory, ssize_t exten
 
 	extent = sendto (channel->fd, memory, extent, 0, (struct sockaddr *) (0), (socklen_t) (0));
 
-#elif defined (__APPLE__) || defined (__OpenBSD__)
+#elif defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__)
 
 	extent = write (channel->fd, memory, extent);
 

--- a/plc/PLCHostBoot.c
+++ b/plc/PLCHostBoot.c
@@ -81,7 +81,7 @@ static signed opensocket (char const * socketname)
 	struct sockaddr_un sockaddr_un =
 	{
 
-#ifdef __OpenBSD__
+#if defined (__OpenBSD__) || defined (__NetBSD__)
 
 		0,
 
@@ -92,7 +92,7 @@ static signed opensocket (char const * socketname)
 	};
 	strncpy (sockaddr_un.sun_path, socketname, sizeof (sockaddr_un.sun_path));
 
-#ifdef __OpenBSD__
+#if defined (__OpenBSD__) || defined (__NetBSD__)
 
 	sockaddr_un.sun_len = SUN_LEN (&sockaddr_un);
 

--- a/plc/plcdevs.c
+++ b/plc/plcdevs.c
@@ -144,7 +144,7 @@ static void enumerate (struct channel * channel, struct nic nic [], unsigned siz
 
 		printf (" %d", nic->ifindex);
 
-#elif defined (__linux__) || defined (__OpenBSD__) || defined (__APPLE__)
+#elif defined (__linux__) || defined (__OpenBSD__) || defined (__NetBSD__) || defined (__APPLE__)
 
 		printf (" %s", nic->ifname);
 

--- a/plc/plchostd.c
+++ b/plc/plchostd.c
@@ -252,7 +252,7 @@ static signed opensocket (char const * socketname)
 	struct sockaddr_un sockaddr_un =
 	{
 
-#if defined (__OpenBSD__) || defined (__APPLE__)
+#if defined (__OpenBSD__) || defined (__NetBSD__) || defined (__APPLE__)
 
 		0,
 
@@ -263,7 +263,7 @@ static signed opensocket (char const * socketname)
 	};
 	strncpy (sockaddr_un.sun_path, socketname, sizeof (sockaddr_un.sun_path));
 
-#if defined (__OpenBSD__) || defined (__APPLE__)
+#if defined (__OpenBSD__) || defined (__NetBSD__) || defined (__APPLE__)
 
 	sockaddr_un.sun_len = SUN_LEN (&sockaddr_un);
 

--- a/plc/plchostd2.c
+++ b/plc/plchostd2.c
@@ -231,7 +231,7 @@ static signed opensocket (char const * socketname)
 	struct sockaddr_un sockaddr_un =
 	{
 
-#if defined (__OpenBSD__) || defined (__APPLE__)
+#if defined (__OpenBSD__) || defined (__NetBSD__) || defined (__APPLE__)
 
 		0,
 
@@ -242,7 +242,7 @@ static signed opensocket (char const * socketname)
 	};
 	strncpy (sockaddr_un.sun_path, socketname, sizeof (sockaddr_un.sun_path));
 
-#if defined (__OpenBSD__) || defined (__APPLE__)
+#if defined (__OpenBSD__) || defined (__NetBSD__) || defined (__APPLE__)
 
 	sockaddr_un.sun_len = SUN_LEN (&sockaddr_un);
 

--- a/serial/int6kbaud.c
+++ b/serial/int6kbaud.c
@@ -63,7 +63,7 @@
 #	include <termios.h>
 #elif defined (__APPLE__)
 #	include <termios.h>
-#elif defined (__OpenBSD__)
+#elif defined (__OpenBSD__) || defined (__NetBSD__)
 #	include <termios.h>
 #else
 #error "Unknown Environment"

--- a/serial/int6kuart.c
+++ b/serial/int6kuart.c
@@ -64,7 +64,7 @@
 #	include <net/ethernet.h>
 #elif defined (__APPLE__)
 #	include <net/ethernet.h>
-#elif defined (__OpenBSD__)
+#elif defined (__OpenBSD__) || defined (__NetBSD__)
 #	include <sys/socket.h>
 #	include <net/if.h>
 #	include <net/if_arp.h>

--- a/serial/openport.c
+++ b/serial/openport.c
@@ -79,7 +79,7 @@
 #elif defined (__APPLE__)
 #	include <termios.h>
 #	include <net/ethernet.h>
-#elif defined (__OpenBSD__)
+#elif defined (__OpenBSD__) || defined (__NetBSD__)
 #	include <termios.h>
 #else
 #error "Unknown Environment"

--- a/serial/ptsctl.c
+++ b/serial/ptsctl.c
@@ -63,7 +63,7 @@
 #	include <termios.h>
 #elif defined (__APPLE__)
 #	include <termios.h>
-#elif defined (__OpenBSD__)
+#elif defined (__OpenBSD__) || defined (__NetBSD__)
 #	include <termios.h>
 #elif defined (WIN32)
 #	include <windows.h>

--- a/serial/weeder.c
+++ b/serial/weeder.c
@@ -63,7 +63,7 @@
 #	include <termios.h>
 #elif defined (__APPLE__)
 #	include <termios.h>
-#elif defined (__OpenBSD__)
+#elif defined (__OpenBSD__) || defined (__NetBSD__)
 #	include <termios.h>
 #elif defined (WIN32)
 #	include <windows.h>

--- a/tools/endian.h
+++ b/tools/endian.h
@@ -70,6 +70,20 @@
  *   definitions;
  *--------------------------------------------------------------------*/
 
+/* Some systems may already define some of these, returnning void */
+#undef HTOBE16
+#undef HTOBE32
+#undef HTOBE64
+#undef HTOLE16
+#undef HTOLE32
+#undef HTOLE64
+#undef BE64TOH
+#undef BE32TOH
+#undef BE16TOH
+#undef LE16TOH
+#undef LE32TOH
+#undef LE64TOH
+
 #if defined (BYTE_ORDER)
 #       if BYTE_ORDER == LITTLE_ENDIAN
 #               define BE16TOH(x) __bswap_16(x)

--- a/tools/endian.h
+++ b/tools/endian.h
@@ -55,6 +55,9 @@
 #       include <libkern/OSByteOrder.h>
 #elif defined (__OpenBSD__)
 #       include <sys/types.h>
+#elif defined (__NetBSD__)
+#       include <sys/types.h>
+#       include <machine/bswap.h>
 #elif defined (WIN32)
 #       include <stdint.h>
 #       define BYTE_ORDER LITTLE_ENDIAN
@@ -165,6 +168,12 @@ uint64_t __bswap_64 (uint64_t x);
 #define __bswap_16(x) swap16(x)
 #define __bswap_32(x) swap32(x)
 #define __bswap_64(x) swap64(x)
+
+#elif defined (__NetBSD__)
+
+#define __bswap_16(x) bswap16(x)
+#define __bswap_32(x) bswap32(x)
+#define __bswap_64(x) bswap64(x)
 
 #elif defined (__APPLE__)
 

--- a/tools/types.h
+++ b/tools/types.h
@@ -37,7 +37,7 @@
 #elif defined (__APPLE__)
 	#define SIZE_T_SPEC "%zu"
 	#define OFF_T_SPEC "%lld"
-#elif defined (__OpenBSD__)
+#elif defined (__OpenBSD__) || defined (__NetBSD__)
 	#define SIZE_T_SPEC "%zu"
 	#define OFF_T_SPEC "%lld"
 #elif defined (__linux__)

--- a/tools/types.h
+++ b/tools/types.h
@@ -69,6 +69,16 @@ typedef unsigned char byte;
 
 #ifndef __cplusplus
 
+#ifdef false
+# undef false
+#endif
+#ifdef true
+# undef true
+#endif
+#ifdef bool
+# undef bool
+#endif
+
 typedef enum
 
 {


### PR DESCRIPTION
Add support for NetBSD. Mostly just adding defined(__NetBSD__) to existing defined(__OpenBSD__), though a couple of cases match the (__APPLE__) case instead, plus the header includes are slightly different.

A couple of commits are made first as they are more generic 'handle any system which already has a 'foo' defined in its system headers'