### PR TITLE
Fix checksum32 for platforms which require aligned memory access

### DIFF
--- a/tools/checksum32.c
+++ b/tools/checksum32.c
@@ -25,34 +25,29 @@
 #ifndef CHECKSUM32_SOURCE
 #define CHECKSUM32_SOURCE
 
+#include <string.h>
 #include <stdint.h>
 #include <memory.h>
 
 #include "../tools/memory.h"
 
-uint32_t checksum32 (register void const * memory, register size_t extent, register uint32_t checksum)
+uint32_t checksum32 (void const * memory, size_t extent, uint32_t checksum)
 
 {
-
-#ifdef __GNUC__
+	uint32_t temp;
 
 	while (extent >= sizeof (checksum))
 	{
-		checksum ^= *(typeof (checksum) *)(memory);
+		/* Since 'memory' might point to an unaligned address,
+		 * we use memcpy to copy the data to 'temp' which is
+		 * aligned. Otherwise, the checksum would be wrong in the
+		 * best case, or worst-case: program is killed with SIGBUS.
+		 */
+		memcpy (&temp, memory, sizeof (temp));
+		checksum ^= temp;
 		memory += sizeof (checksum);
 		extent -= sizeof (checksum);
 	}
-
-#else
-
-	uint32_t * offset = (uint32_t *)(memory);
-	while (extent >= sizeof (* offset))
-	{
-		checksum ^= *offset++;
-		extent -= sizeof (* offset);
-	}
-
-#endif
 
 	return (~checksum);
 }


### PR DESCRIPTION
We recently discovered, that running plcID on our I2SE Duckbill
devices (ARM) failed with the following error:

plcID: ReadKey2 found bad NVM header checksum in device module 0

After investigating, we found that this is an alignment issue. The
problem is casting the void memory pointer to an uint32_t pointer
since the latter one must be aligned on ARM. See [1] for reference
with a pointer to the C spec (in short: such a cast is undefined
behaviour).

To fix this issue, always use memcpy (which does the right thing
in all cases) to copy the data to an aligned temporary location
and use this one for calculating the checksum.

While at, remove the 'register' decoration from the function
prototype - let the compiler do the job. Also drop the alternate
compiler path, this new implementation should be generic enough
to work on all platforms.

Additional notes:
To debug this alignment issues, you can enable alignment warnings
with: echo 1 > /proc/cpu/alignment
Then you'll find messages like (wrapped for better readability)
in your kernel log:
[29572.476952] Alignment trap: checksum32 (4183) PC=0x000104ec
  Instr=0xe5932000 Address=0xbed16845 FSR 0x001

[1] https://lists.debian.org/debian-gcc/2005/08/msg00412.html

Signed-off-by: Michael Heimpold michael.heimpold@i2se.com
