### PR TITLE
SetNMK.c: remove unused variable declaration

### DIFF
--- a/plc/SetNMK.c
+++ b/plc/SetNMK.c
@@ -71,7 +71,6 @@
 signed SetNMK (struct plc * plc)
 
 {
-	extern const byte localcast [ETHER_ADDR_LEN];
 	struct channel * channel = (struct channel *)(plc->channel);
 	struct message * message = (struct message *)(plc->message);
 


### PR DESCRIPTION
This prevents a compiler warning.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>