### PR TITLE
NetInfo: Print OSA to stdout

### DIFF
--- a/plc/NetInfo1.c
+++ b/plc/NetInfo1.c
@@ -138,6 +138,8 @@ signed NetInfo1 (struct plc * plc)
 	{
 		char string [24];
 		Confirm (plc, "Found %d Network(s)\n", networks->NUMAVLNS);
+		hexdecode (message->ethernet.OSA, sizeof (message->ethernet.OSA), string, sizeof (string));
+		printf("source address = %s\n\n", string);
 		network = (struct network *)(&networks->networks);
 		while (networks->NUMAVLNS--)
 		{

--- a/plc/NetInfo2.c
+++ b/plc/NetInfo2.c
@@ -150,6 +150,8 @@ signed NetInfo2 (struct plc * plc)
 	{
 		char string [24];
 		Confirm (plc, "Found %d Network(s)\n", networks->NUMAVLNS);
+		hexdecode (message->ethernet.OSA, sizeof (message->ethernet.OSA), string, sizeof (string));
+		printf("source address = %s\n\n", string);
 		network = (struct network *)(&networks->networks);
 		while (networks->NUMAVLNS--)
 		{


### PR DESCRIPTION
In order to keep the relation between response address and network(s)
we should prepend the OSA in stdout because the output of Confirm()
isn't always reliable (output could be silented or buffering issues could mix up the order).