### PR TITLE
Some minor fixes for several manpages

### DIFF
--- a/mdio/.gitignore
+++ b/mdio/.gitignore
@@ -2,3 +2,4 @@ mdioblock
 mdioblock2
 mdiodump
 mdiogen
+mdio.bin

--- a/mdio/Makefile
+++ b/mdio/Makefile
@@ -16,7 +16,7 @@ LDFLAGS+=
 TRASH=*.o *.obj *.exe t t.* *~ *.[0-9][0-9][0-9]
 FILES=Makefile *.mak *.sh *.c *.h 
 TOOLS=mdioblock mdioblock2 mdiodump mdiogen
-PAGES=mdioblock.1 mdioblock2.1 mdiodump.1
+PAGES=mdioblock.1 mdioblock2.1 mdiodump.1 mdiogen.1
 
 # ====================================================================
 # pseudo targets;

--- a/mdio/mdiogen.1
+++ b/mdio/mdiogen.1
@@ -1,0 +1,47 @@
+.TH mdiogen 1 "November 2013" "open-plc-utils-0.0.3" "Qualcomm Atheros Open Powerline Toolkit"
+
+.SH NAME
+mdiogen - Qualcomm Atheros MDIO Custom Module Generator
+
+.SH SYNOPSIS
+.BR mdiogen
+
+.SH DESCRIPTION
+Produces an MDIO program block from a fixed compiled-in array and outputs it
+to fixed file named \fBmdio.bin\fR.
+
+.PP
+This program is part of the Qualcomm Atheros Powerline Toolkit.
+See the \fBPLC\fR man page for an overview and installation instructions.
+
+.SH REFERENCES
+See the Qualcomm Atheros \fIHomePlug AV Firmware Technical Reference Manual\fR for information about
+generic MDIO register instruction.
+See the Qualcomm Atheros \fIAR8236 Six-Port Fast Ethernet Switch Data Sheet\fR for detailed
+information about AR8236 specific MDIO registers and instructions.
+
+.SH DISCLAIMER
+Atheros HomePlug AV Vendor Specific Management Message structure and content is proprietary to
+Qualcomm Atheros, Ocala FL USA.
+Consequently, public information may not be available.
+Qualcomm Atheros reserves the right to modify message structure and content in future firmware
+releases without any obligation to notify or compensate users of this program.
+
+.SH EXAMPLES
+None.
+
+.SH SEE ALSO
+.BR amp ( 1 ),
+.BR int6kmod ( 1 ),
+.BR int6kmdio ( 1 ),
+.BR int6kmdio2 ( 1 ),
+.BR mdioblock ( 1 ),
+.BR mdioblock2 ( 1 ),
+.BR mdiogen ( 1 ),
+.BR plcmdio16 ( 1 ),
+.BR plcmdio32 ( 1 )
+
+.SH CREDITS
+ Nathaniel Houghton
+ Charles Maier
+ Marc Bertola

--- a/plc/coqos_man.1
+++ b/plc/coqos_man.1
@@ -98,7 +98,8 @@ A synonym for the Qualcomm Atheros vendor specific Local Management Address (LMA
 All local Atheros devices recognize this address but remote and foreign devices do not.
 A remote device is any device at the far end of a powerline connection.
 A foreign device is any device not manufactured by Atheros.
-..SH REFERENCES
+
+.SH REFERENCES
 See the Qualcomm Atheros HomePlug AV Firmware Technical Reference Manual for more information.
 
 .SH DISCLAIMER

--- a/plc/mdustats.1
+++ b/plc/mdustats.1
@@ -1,7 +1,7 @@
 .TH mdustats 1 "November 2013" "open-plc-utils-0.0.3" "Qualcomm Atheros Open Powerline Toolkit"
 
 .SH NAME
-mdustats
+mdustats - MDU traffic statistics
 
 .SH SYNOPSIS
 .BR mdustats
@@ -11,7 +11,7 @@ mdustats
 [...]
 
 .SH DESCRIPTION
-Collect and display MDU traffic statisitcs using the Qualcomm Atheros vendor specific VS_MDU_TRAFFIC_STATS message.
+Collect and display MDU traffic statistics using the Qualcomm Atheros vendor specific VS_MDU_TRAFFIC_STATS message.
 
 .PP
 This program is part of the Qualcomm Atheros Powerline Toolkit.

--- a/plc/plc.1
+++ b/plc/plc.1
@@ -1,7 +1,7 @@
 .TH plc 1 "November 2013" "open-plc-utils-0.0.3" "Qualcomm Atheros Open Powerline Toolkit"
 
 .SH NAME
-Qualcomm Atheros Powerline Toolkit 
+Qualcomm Atheros Powerline Toolkit - Tools to manage and control HomePlug 1.0 and HomePlug AV devices
 
 .SH SYNOPSIS
 Qualcomm Atheros provides the \fBPowerline Toolkit\fR to customers free of charge.

--- a/slac/evse.1
+++ b/slac/evse.1
@@ -17,7 +17,7 @@ See the \fIHomePlug Green PHY Specification Release Version 1.1\fR for more info
 Signal Level Attenuation Characterization (SLAC) enables a station to measure the signal level of its transmission at other stations in the network.
 It is designed for automotive applications where there are multiple plug-in vehicle (PEVs) and electric vehicle supply equipment (EVSE) on the network.
 The PEV signal level is measured at multiple EVSEs to determine which EVSE the PEV is actually plugged into.
-The process leading to this determination is called "\fBGreen PHY PEV-EVSE Association\fB" (GreenPPEA).
+The process leading to this determination is called "\fBGreen PHY PEV-EVSE Association\fR" (GreenPPEA).
 
 .PP
 This program is part of the Qualcomm Atheros Powerline Toolkit.
@@ -86,9 +86,9 @@ Use this option when sending screen dumps to Atheros Technical Support so that t
 .SH PROFILE
 The default configuration profile for this program is "\fBevse.ini\fR".
 The default profile section is "\fBdefault\fR".
-Users may create addition profiles and reference them with option \fB-p\fr or add additional sections to an existing profiles and reference them with option \fB-s\fR.
+Users may create addition profiles and reference them with option \fB-p\fR or add additional sections to an existing profiles and reference them with option \fB-s\fR.
 
-.TP 
+.TP
 .B Time to Sound
 The time in 100 millisecond increments for all msounds to arrive at the msound target.
 The msound target may proceed with attenuation characterization computations should all msounds fail to arrive within this period.
@@ -96,8 +96,8 @@ This value is read but not used by program \fBpev\fR or program \fBevse\fR.
 This value is the same as CM_SLAC_PARAM.CNF.TIME_OUT.
 The default value is \fB10\fR which represents 1000 milliseconds.
 
-.TP 
-.B Number of Sounds 
+.TP
+.B Number of Sounds
 
 .TP
 The total number of msounds that will be sent to the msound target.
@@ -165,6 +165,3 @@ Use option \fB-P\fR to produce a template profile, if one is needed.
 
 .SH CREDITS
  Charles Maier
-'
-'
-

--- a/slac/pev.1
+++ b/slac/pev.1
@@ -17,7 +17,7 @@ See the \fIHomePlug Green PHY Specification Release Version 1.1\fR for more info
 Signal Level Attenuation Characterization (SLAC) enables a station to measure the signal level of its transmission at other stations in the network.
 It is designed for automotive applications where there are multiple plug-in vehicle (PEVs) and electric vehicle supply equipment (EVSE) on the network.
 The PEV signal level is measured at multiple EVSEs to determine which EVSE the PEV is actually plugged into.
-The process leading to this determination is called "\fBGreen PHY PEV-EVSE Association\fB" (GreenPPEA).
+The process leading to this determination is called "\fBGreen PHY PEV-EVSE Association\fR" (GreenPPEA).
 
 .PP
 This program is part of the Qualcomm Atheros Powerline Toolkit.
@@ -84,7 +84,7 @@ Use this option when sending screen dumps to Atheros Technical Support so that t
 .SH PROFILES
 The default configuration profile for this program is "\fBpev.ini\fR".
 The default profile section is "\fBdefault\fR".
-Users may create addition profiles and reference them with option \fB-p\fr or add additional sections to an existing profiles and reference them with option \fB-s\fR.
+Users may create addition profiles and reference them with option \fB-p\fR or add additional sections to an existing profiles and reference them with option \fB-s\fR.
 
 .TP
 .B Attenuation Theshold
@@ -148,4 +148,3 @@ Use option \fB-P\fR to produce a template profile, if one is needed.
 
 .SH CREDITS
  Charles Maier
-


### PR DESCRIPTION
Mostly typos which causes formatting errors. Spotted during building Debian packages by lintian checks.