### PR TITLE
README: split make process into two steps (fixes #103)

### DIFF
--- a/README
+++ b/README
@@ -55,25 +55,26 @@
  *
  *--------------------------------------------------------------------*/
 
-This package is an open version of the Qualcomm Atheros Powerline 
+This package is an open version of the Qualcomm Atheros Powerline
 Toolkit. It may be distributed as a zip, gzip or bzip2 tarball that
-contains source code and build scripts for Linux, OpenBSD, MAC OSX 
-and Microsoft Windows. It also contains documentation in docbook XML, 
-HTML and plain text format. 
+contains source code and build scripts for Linux, OpenBSD, MAC OSX
+and Microsoft Windows. It also contains documentation in docbook XML,
+HTML and plain text format.
 
-We recommend that you open file docbook/index.html with a web browser 
-the read Chapter 1 before attempting to install or use the toolkit 
-but the impatient may do the following and survive ...
+We recommend that you open file docbook/index.html with a web browser
+the read Chapter 1 before attempting to install or use the toolkit
+but the impatient may do the following and survive...
 
 TO INSTALL
 ----------
 
 1. Enter package folder using "cd open-plc-utils".
-2. Compile and install all tools in /usr/local/bin using "sudo make install". 
-3. Compile and install man pages in  /usr/share/man/man1 using "sudo make manuals".
-4  Change to the documentation folder using "cd docbook".
-5. Add page index.html to browser favorites.
-6. Add page toolkit.html to browser favorites.
+2. Compile all tools using "make".
+3. Install all tools to /usr/local/bin using "sudo make install".
+4. Compile and install man pages in  /usr/share/man/man1 using "sudo make manuals".
+5  Change to the documentation folder using "cd docbook".
+6. Add page index.html to browser favorites.
+7. Add page toolkit.html to browser favorites.
 
 Note: 'make' is assumed to be the GNU make command (often available
       under the name 'gmake').
@@ -90,6 +91,7 @@ Note: 'make' is assumed to be the GNU make command (often available
 
 CONTRIBUTORS
 ------------
+
 Alejandro Vasquez <avasquez@qca.qualcomm.com>
 Abdel Younes <younes@leacom.fr>
 Andrew Barnes <abarnes@qca.qualcomm.com>


### PR DESCRIPTION
The compilation itself should normally be run without elevated privileges,
so split it from the install step.

While at, adjust some minor formatting issues.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>