### PR TITLE
 Change default manpage installation destination to /usr/local hierarchy

### DIFF
--- a/ether/Makefile
+++ b/ether/Makefile
@@ -36,6 +36,7 @@ install: $(TOOLS) library
 	install -m ${SUID_PERM} -o ${OWNER} -g ${GROUP} ${TOOLS} ${BIN}
 uninstall:
 	cd ${BIN}; rm -f ${TOOLS}
+	cd ${MAN}; rm -f ${PAGES}
 check:
 	${SHELL} ether.sh
 fresh: clean compile

--- a/make.def
+++ b/make.def
@@ -67,7 +67,7 @@ STRIP=$(CROSS)strip
 
 ROOTFS?=
 BIN=${ROOTFS}/usr/local/bin
-MAN=${ROOTFS}/usr/share/man/man1
+MAN=${ROOTFS}/usr/local/man/man1
 DOC=${ROOTFS}/home/www/software
 WWW=${ROOTFS}/home/www
 FTP=${ROOTFS}/home/ftp

--- a/mme/Makefile
+++ b/mme/Makefile
@@ -36,6 +36,7 @@ install: $(TOOLS) library
 	install -m ${BIN_PERM} -o ${OWNER} -g ${GROUP} ${TOOLS} ${BIN}
 uninstall:
 	cd ${BIN}; rm -f ${TOOLS}
+	cd ${MAN}; rm -f ${PAGES}
 check:
 	${SHELL} mme.sh
 fresh: clean compile

--- a/nvm/Makefile
+++ b/nvm/Makefile
@@ -36,6 +36,7 @@ install: $(TOOLS) library
 	install -m ${BIN_PERM} -o ${OWNER} -g ${GROUP} ${TOOLS} ${BIN}
 uninstall:
 	cd ${BIN}; rm -f ${TOOLS}
+	cd ${MAN}; rm -f ${PAGES}
 check:
 	${SHELL} nvm.sh
 fresh: clean compile

--- a/pib/Makefile
+++ b/pib/Makefile
@@ -37,7 +37,8 @@ library:
 install: $(TOOLS) library
 	install -m ${BIN_PERM} -o ${OWNER} -g ${GROUP} ${TOOLS} ${BIN}
 uninstall:
-	cd ${BIN}; rm -f ${TOOLS} 
+	cd ${BIN}; rm -f ${TOOLS}
+	cd ${MAN}; rm -f ${PAGES}
 check:
 	${SHELL} pib.sh
 fresh: clean compile

--- a/plc/Makefile
+++ b/plc/Makefile
@@ -40,8 +40,8 @@ manuals:
 install: $(TOOLS) library
 	install -m ${SUID_PERM} -o ${OWNER} -g ${GROUP} ${TOOLS} ${BIN}
 uninstall:
-	cd ${BIN}; rm -f int6k ${TOOLS}
-	cd ${MAN}; rm -f int6k ${PAGES}
+	cd ${BIN}; rm -f ${TOOLS}
+	cd ${MAN}; rm -f ${PAGES}
 check:
 	${SHELL} plc.sh
 fresh: clean compile

--- a/slac/Makefile
+++ b/slac/Makefile
@@ -35,8 +35,8 @@ manuals:
 install: compile library
 	install -m ${SUID_PERM} -o ${OWNER} -g ${GROUP} ${TOOLS} ${BIN}
 uninstall:
-	cd ${BIN}; rm -f plc ${TOOLS}
-	cd ${MAN}; rm -f plc ${PAGES}
+	cd ${BIN}; rm -f ${TOOLS}
+	cd ${MAN}; rm -f ${PAGES}
 clean:
 	rm -f ${TRASH} ${TOOLS}
 check:


### PR DESCRIPTION
Since we install the binary programs to /usr/local hierarchy by default,
we should also use the /usr/local hierarchy for manpages and do not mess
with /usr/share/man directories which are usually managed by distributions.

This allows better tracking of user installed manpages and is a cleaner
approach in general.