### PR TITLE
Allow to focus on exchanging soundings only during SLAC

### DIFF
--- a/slac/evse.1
+++ b/slac/evse.1
@@ -52,6 +52,15 @@ The default interface is \fBeth1\fR because most people use \fBeth0\fR as their 
 This option then takes precedence over either default.
 
 .TP
+.RB - K
+Skip the step which sets the Network Membership Key and focus on sounding only.
+
+.TP
+.RB - l
+Normally, this tool loops indefinitely. Use this parameter to exit after one iteration.
+Note, that this parameter has inverse logic compared to \fBpev\fR tool.
+
+.TP
 -\fBp \fIprofile\fR
 The EVSE-HLE configuration profile name.
 The program will supply default values for missing profile elements.

--- a/slac/evse.1
+++ b/slac/evse.1
@@ -5,7 +5,7 @@ evse - Qualcomm Atheros Electric Vehicle Supply Equipment Emulator
 
 .SH SYNOPSIS
 .BR evse
-.RI [ options ] 
+.RI [ options ]
 
 .SH DESCRIPTION
 Emulate the EVSE part of the HomePlug AV Signal Level Attentuation Characterization (SLAC) protocol where a \fBPEV\fR is a "\fBPlug-in Electric Vehicle\fR" and an \fBEVSE\fR is an "\fBElectric Vehicle Supply Equipment\fR" or charging station.
@@ -32,12 +32,15 @@ The configuration profile specifies program defaults in a format that you, as a 
 Use options \fB-p\fR and \fB-s\fR to read named profiles and sections.
 
 .TP
+.RB - C
+Compare confirmation counter and warn (or exit - if \fB-x\fR is given) if a mismatch is detected.
+
+.TP
 .RB - d
 Print the contents of the EVSE-HLE session variable on stdout.
 The session variable is an program data structure that stores information passed between the PEV-HLE and EVSE-HLE during SLAC association.
-This option is used to inspect and veriify information relevant to the process.
+This option is used to inspect and verify information relevant to the process.
 
-.PP
 If the program was compiled with variable SLAC_DEBUG defined then this option also prints MME message fields before messages are sent or after they are received.
 Interested parties can follow along in the source code.
 
@@ -68,9 +71,17 @@ See the example profile shown below.
 The default section name is "\fBdefault\fR".
 
 .TP
-.RB - v 
+-\fBt \fImilliseconds\fR
+Channel read/write timeout in milliseconds.
+
+.TP
+.RB - v
 Enter verbose mode.
-All Etherenet frames sent or received by the program are displayed on stdout.
+All Ethernet frames sent or received by the program are displayed on stdout.
+
+.TP
+.RB - x
+Exit on error.
 
 .TP
 -\fB?\fR, --\fBhelp\fR
@@ -86,7 +97,7 @@ Use this option when sending screen dumps to Atheros Technical Support so that t
 .SH PROFILE
 The default configuration profile for this program is "\fBevse.ini\fR".
 The default profile section is "\fBdefault\fR".
-Users may create addition profiles and reference them with option \fB-p\fR or add additional sections to an existing profiles and reference them with option \fB-s\fR.
+Users may create additional profiles and reference them with option \fB-p\fR or add additional sections to an existing profiles and reference them with option \fB-s\fR.
 
 .TP
 .B Time to Sound
@@ -99,7 +110,6 @@ The default value is \fB10\fR which represents 1000 milliseconds.
 .TP
 .B Number of Sounds
 
-.TP
 The total number of msounds that will be sent to the msound target.
 All msounds must arrive within the allotted time or they will be lost.
 This value is the same as CM_SLAC_PARAM.CNF.NUM_SOUNDS.
@@ -133,11 +143,8 @@ The default value is the same as that for Network Password "\fBHomePlugAV0123\fR
 .SH REFERENCES
 See the \fIQualcomm Atheros AR7420, QCA6410 IEEE 1901, HomePlug AV and QCA7000 HomePlug Green PHY PLC Chipset Programmer's Guide\fR or the \fIHomePlug Green PHY Specification Release Version 1.1\fR for more information on this protocol.
 
-.SH REFERENCES
-See the \fIQualcomm Atheros AR7420, QCA6410 IEEE 1901, HomePlug AV and QCA7000 HomePlug Green PHY PLC Chipset Programmer'sw Guide\fR or the \fIHomePlug Green PHY Specification Release Version 1.1\fR for more information on this protocol.
-
 .SH EXAMPLES
-The following example starts a EVSE session on interface \fBeth0\fR and wait up to 2000 milliseconds (or 2 seconds) for the PEV to respond during any given exchange.
+The following example starts an EVSE session on interface \fBeth0\fR and wait up to 2000 milliseconds (or 2 seconds) for the PEV to respond during any given exchange.
 
 .PP
    # evse -ieth0 -w2000
@@ -148,9 +155,9 @@ Use option \fB-P\fR to produce a template profile, if one is needed.
 
 .PP
    # file: evse.ini
-   # ====================================================================
+   # ========================================================
    # EVSE-HLE initiaization;
-   # --------------------------------------------------------------------
+   # --------------------------------------------------------
    [default]
    time to sound = 10
    number of sounds = 8

--- a/slac/pev.1
+++ b/slac/pev.1
@@ -52,8 +52,13 @@ The default interface is \fBeth1\fR because most people use \fBeth0\fR as their 
 This option then takes precedence over either default.
 
 .TP
+.RB - K
+Skip the step which sets the Network Membership Key and focus on sounding only.
+
+.TP
 .RB - l
 Normally, this tool exits after one run. Use this parameter to loop indefinitely.
+Note, that this parameter has inverse logic compared to \fBevse\fR tool.
 
 .TP
 -\fBp \fIprofile\fR

--- a/slac/pev.1
+++ b/slac/pev.1
@@ -5,7 +5,7 @@ pev - Qualcomm Atheros Plug-in Electric Vehicle Emulator
 
 .SH SYNOPSIS
 .BR pev
-.RI [ options ] 
+.RI [ options ]
 
 .SH DESCRIPTION
 Emulate the PEV part of the HomePlug AV Signal Level Attentuation Characterization (SLAC) protocol where a \fBPEV\fR is a "\fBPlug-in Electric Vehicle\fR" and an \fBEVSE\fR is an "\fBElectric Vehicle Supply Equipment\fR" or charging station.
@@ -32,10 +32,15 @@ The configuration profile specifies program defaults in a format that you, as a 
 Use options \fB-p\fR and \fB-s\fR to read named profiles and sections.
 
 .TP
+.RB - C
+Compare confirmation counter and warn (or exit - if \fB-x\fR is givenv) if a mismatch is detected.
+
+.TP
 .RB - d
 Print the contents of the PEV-HLE session variable on stdout.
 The session variable is an program data structure that stores information passed between the PEV-HLE and EVSE-HLE during SLAC association.
 This option is used to inspect and veriify information relevant to the process.
+
 If the program was compiled with variable SLAC_DEBUG defined then this option also prints MME message fields before messages are sent or after they are received.
 Interested parties can follow along in the source code.
 
@@ -45,6 +50,10 @@ Select the host Ethernet interface.
 All requests are sent via this host interface and only reponses received via this host interface are recognized.
 The default interface is \fBeth1\fR because most people use \fBeth0\fR as their principle network connection; however, if environment string "PLC" is defined then it takes precedence over the default interface.
 This option then takes precedence over either default.
+
+.TP
+.RB - l
+Normally, this tool exits after one run. Use this parameter to loop indefinitely.
 
 .TP
 -\fBp \fIprofile\fR
@@ -66,9 +75,13 @@ See the example profile shown below.
 The default section name is "\fBdefault\fR".
 
 .TP
-.RB - v 
+.RB - v
 Enter verbose mode.
-All Etherenet frames sent or received by the program are displayed on stdout.
+All Ethernet frames sent or received by the program are displayed on stdout.
+
+.TP
+.RB - x
+Exit on error.
 
 .TP
 -\fB?\fR, --\fBhelp\fR
@@ -84,7 +97,7 @@ Use this option when sending screen dumps to Atheros Technical Support so that t
 .SH PROFILES
 The default configuration profile for this program is "\fBpev.ini\fR".
 The default profile section is "\fBdefault\fR".
-Users may create addition profiles and reference them with option \fB-p\fR or add additional sections to an existing profiles and reference them with option \fB-s\fR.
+Users may create additional profiles and reference them with option \fB-p\fR or add additional sections to an existing profiles and reference them with option \fB-s\fR.
 
 .TP
 .B Attenuation Theshold
@@ -118,7 +131,7 @@ This program uses CM_SET_KEY to sets the PEV-PLC NID to this value after disconn
 The default value is the same as that for Network Password "\fBHomePlugAV\fR".
 
 .SH REFERENCES
-See the \fIQualcomm Atheros AR7420, QCA6410 IEEE 1901, HomePlug AV and QCA7000 HomePlug Green PHY PLC Chipset Programmer''s Guide\fR or the \fIHomePlug Green PHY Specification Release Version 1.1\fR for more information on this protocol.
+See the \fIQualcomm Atheros AR7420, QCA6410 IEEE 1901, HomePlug AV and QCA7000 HomePlug Green PHY PLC Chipset Programmer's Guide\fR or the \fIHomePlug Green PHY Specification Release Version 1.1\fR for more information on this protocol.
 
 .SH EXAMPLES
 The following example starts a PEV session on interface \fBeth0\fR and wait up to 2000 milliseconds (or 2 seconds) for the EVSE to respond during any given exchange.
@@ -132,9 +145,9 @@ Use option \fB-P\fR to produce a template profile, if one is needed.
 
 .PP
    # file: pev.ini
-   # ====================================================================
+   # ========================================================
    # PEV-HLE initialization;
-   # --------------------------------------------------------------------
+   # --------------------------------------------------------
    [default]
    attenuation threshold = 10
    msound pause = 10

--- a/slac/slac.h
+++ b/slac/slac.h
@@ -108,10 +108,11 @@
 #define SLAC_CHARGETIME 2
 #define SLAC_FLAGS 0
 
-#define SLAC_SILENCE (1 << 0)
-#define SLAC_VERBOSE (1 << 1)
-#define SLAC_SESSION (1 << 2)
-#define SLAC_COMPARE (1 << 3)
+#define SLAC_SILENCE   (1 << 0)
+#define SLAC_VERBOSE   (1 << 1)
+#define SLAC_SESSION   (1 << 2)
+#define SLAC_COMPARE   (1 << 3)
+#define SLAC_SOUNDONLY (1 << 4)
 
 #define SLAC_CM_SETKEY_KEYTYPE 0x01
 #define SLAC_CM_SETKEY_PID 0x02


### PR DESCRIPTION
The QCA7000 firmware (or better: HomePlug Green PHY as such) does not provide rich possibilities for connection quality checks like other chipsets do. For example with QCA7500 it's possible to transfer some amount of data, then check the average data rate and use this value as connection quality indicator. As this is not possible with QCA7000, one possible indicator value could be the signal attenuation when both sides are SLAC capable.

This PR modifies the existings tools _evse_ and _pev_ to allow focusing on the sounding step only. In other words, it is possible to use the part of a complete SLAC session to determine the attenuation between two PLC peers without the overhead of changing NMK, waiting for QCA7000 reboots etc.
This is intended to be used e.g. in a test bed where this overhead is not desired or required.

And while documenting the new parameters, this PR also contains patches to bring the man pages back in sync with implementation.

Signed-off-by: Michael Heimpold <michael.heimpold@i2se.com>

