### PR TITLE
plcrate: introduce command line parameter -s

### DIFF
--- a/plc/Traffic2.c
+++ b/plc/Traffic2.c
@@ -175,7 +175,10 @@ signed Traffic2 (struct plc * plc)
 		while (devices-- > 1)
 		{
 			Transmit (plc, devicelist [0], devicelist [devices]);
-			Antiphon (plc, devicelist [devices], devicelist [0]);
+			if (_allclr (plc->flags, PLC_TXONLY))
+			{
+				Antiphon (plc, devicelist [devices], devicelist [0]);
+			}
 		}
 	}
 	return (0);

--- a/plc/amprate.c
+++ b/plc/amprate.c
@@ -177,7 +177,7 @@ void manager (struct plc * plc, signed count, signed pause)
 		{
 			PhyRates2 (plc);
 		}
-		if (_anyset (plc->flags, (PLC_TXONLY|PLC_RXONLY)))
+		if (_anyset (plc->flags, PLC_RXONLY))
 		{
 			RxRates2 (plc);
 		}
@@ -350,7 +350,7 @@ int main (int argc, char const * argv [])
 	}
 	argc -= optind;
 	argv += optind;
-	if (_allclr (plc.flags, (PLC_VERSION | PLC_LOCAL_TRAFFIC | PLC_NETWORK_TRAFFIC | PLC_RESET_DEVICE | PLC_TXONLY | PLC_RXONLY)))
+	if (_allclr (plc.flags, (PLC_VERSION | PLC_LOCAL_TRAFFIC | PLC_NETWORK_TRAFFIC | PLC_RESET_DEVICE | PLC_RXONLY)))
 	{
 		_setbits (plc.flags, PLC_NETWORK);
 	}

--- a/plc/plcrate.1
+++ b/plc/plcrate.1
@@ -77,6 +77,13 @@ Reads device hardware and software revision information using VS_SW_VER and prin
 Resets the device using VS_RS_DEV.
 
 .TP
+.RB - s
+Generate only TX traffic between the local device and each remote device on powerline network.
+This option is useful to speed up PLC network testing if the test is run on every node and
+each receiving side is checked individually. In other words: this flag is only used in combination
+with \fB-t\fR (one-to-many), not when generating traffic between all powerline peers.
+
+.TP
 .RB - t
 Generate powerline traffic between the local device and each remote device on each powerline network connected to the host.
 It does not generate any traffic between remote powerline device pairs.

--- a/plc/plcrate.c
+++ b/plc/plcrate.c
@@ -219,7 +219,7 @@ int main (int argc, char const * argv [])
 	extern struct channel channel;
 	static char const * optv [] =
 	{
-		"cd:ei:l:o:nqrRtTuvw:x",
+		"cd:ei:l:o:nqrRstTuvw:x",
 		"device [device] [...]",
 		"Qualcomm Atheros PLC PHY Rate Monitor",
 		"c\tdisplay coded PHY rates",
@@ -242,6 +242,7 @@ int main (int argc, char const * argv [])
 		"q\tquiet mode",
 		"r\trequest device information",
 		"R\treset device with VS_RS_DEV",
+		"s\tgenerate TX traffic only",
 		"t\tgenerate network traffic (one-to-many)",
 		"T\tgenerate network traffic (many-to-many)",
 		"u\tdisplay uncoded PHY rates",
@@ -314,6 +315,9 @@ int main (int argc, char const * argv [])
 			break;
 		case 'R':
 			_setbits (plc.flags, PLC_RESET_DEVICE);
+			break;
+		case 's':
+			_setbits (plc.flags, PLC_TXONLY);
 			break;
 		case 't':
 			_setbits (plc.flags, PLC_LOCAL_TRAFFIC);


### PR DESCRIPTION
This introduces the commmand line switch -s which allows to
fine-control the network traffic generation: it suppresses
the generation of "antiphon" traffic, i.e. RX traffic (from
remote peer to local one) and thus speed-ups network testing
scenarios. This flag is only used in combination with
-t flag (one-to-many case) - the many-to-many case (-T) is
not affected.

For this is (re-)uses a flag PLC_TXONLY which requires minor
changes in amprate to keep existing behaviour of amprate.
(this flag was not usable in amprate - so I guess it is ok).

Also the man page is updated for plcrate to document this new
parameter.

Signed-off-by: Michael Heimpold <michael.heimpold@i2se.com>