### PR TITLE
plcstat/int6kstat: allow to query a powerline device for topology directly

### DIFF
--- a/plc/Topology1.c
+++ b/plc/Topology1.c
@@ -73,6 +73,7 @@
 signed Topology1 (struct plc * plc)
 
 {
+	extern const byte localcast [ETHER_ADDR_LEN];
 	struct channel * channel = (struct channel *)(plc->channel);
 	struct message * message = (struct message *)(plc->message);
 
@@ -126,7 +127,16 @@ signed Topology1 (struct plc * plc)
 #endif
 
 	byte list [255] [ETHER_ADDR_LEN];
-	signed bridges = LocalDevices (channel, message, list, sizeof (list));
+	signed bridges;
+	if (memcmp (channel->peer, localcast, sizeof (channel->peer)) != 0)
+	{
+		bridges = 1;
+		memcpy (&list, channel->peer, sizeof (channel->peer));
+	}
+	else
+	{
+		bridges = LocalDevices (channel, message, list, sizeof (list));
+	}
 	while (bridges--)
 	{
 		char address [ETHER_ADDR_LEN * 3];

--- a/plc/Topology2.c
+++ b/plc/Topology2.c
@@ -76,6 +76,7 @@
 signed Topology2 (struct plc * plc)
 
 {
+	extern const byte localcast [ETHER_ADDR_LEN];
 	struct channel * channel = (struct channel *)(plc->channel);
 	struct message * message = (struct message *)(plc->message);
 
@@ -141,7 +142,16 @@ signed Topology2 (struct plc * plc)
 #endif
 
 	uint8_t list [255] [ETHER_ADDR_LEN];
-	signed bridges = LocalDevices (channel, message, list, sizeof (list));
+	signed bridges;
+	if (memcmp (channel->peer, localcast, sizeof (channel->peer)) != 0)
+	{
+		bridges = 1;
+		memcpy (&list, channel->peer, sizeof (channel->peer));
+	}
+	else
+	{
+		bridges = LocalDevices (channel, message, list, sizeof (list));
+	}
 	while (bridges--)
 	{
 		char address [ETHER_ADDR_LEN * 3];

--- a/plc/int6kstat.1
+++ b/plc/int6kstat.1
@@ -5,9 +5,8 @@ int6kstat - Qualcomm Atheros INT6x00 Link Statistics
 
 .SH SYNOPSIS
 .BR int6kstat
-.RI [ options ] 
-.RI [ device ] 
-.RI [ device ] 
+.RI [ options ]
+.RI [ device ]
 [...]
 
 .SH DESCRIPTION
@@ -21,7 +20,7 @@ See the \fBplc\fR man page for an overview and installation instructions.
 .SH OPTIONS
 
 .TP
-.RB -C
+.RB - C
 Clear device link statistics using VS_LNK_STATS.
 Statistics are read and cleared then displayed.
 The statistics that are read and displayed depend on options \fB-d\fR, \fB-p\fR and \fB-s\fR but all link statistics are cleared.
@@ -78,12 +77,14 @@ The default Link ID is \fB0xFC\fR.
 .RB - t
 Display network topology using VS_SW_VER and VS_NW_INFO messages.
 This option is similar to option \fB-m\fR but provides complete network topology plus device hardware and firmware version.
-Topology is always relative to the local host, or local hosts if present.
-Powerline devices that appear on the command line are not used for this operation.
-PHY rates displaye by this option may saturate at 255 mbps.
+Topology is relative to the queried powerline device(s) given on the command line. If no device is given explicitly,
+then it is tried to determine all local devices (you can also use \fBlocal\fR instead).
+However, this can fail if you have the local powerline device(s) not directly connected but via a switch which
+does not broadcast the Qualcomm Atheros vendor specific Local Management Address (LMA) to all ports.
+PHY rates displayed by this option may saturate at 255 Mbps.
 
 .TP
-.RB - v 
+.RB - v
 Enter verbose mode.
 All Etherenet frames sent or received by the program are displayed on stdout.
 

--- a/plc/plcstat.1
+++ b/plc/plcstat.1
@@ -5,9 +5,8 @@ plcstat - Qualcomm Atheros AR7x00 Link Statistics
 
 .SH SYNOPSIS
 .BR plcstat
-.RI [ options ] 
-.RI [ device ] 
-.RI [ device ] 
+.RI [ options ]
+.RI [ device ]
 [...]
 
 .SH DESCRIPTION
@@ -26,7 +25,7 @@ Older firmware versions may not recognize this message version.
 .SH OPTIONS
 
 .TP
-.RB -C
+.RB - C
 Clear device link statistics using VS_LNK_STATS.
 Statistics are read and cleared then displayed.
 The statistics that are read and displayed depend on options \fB-d\fR, \fB-p\fR and \fB-s\fR but all link statistics are cleared.
@@ -83,11 +82,13 @@ The default Link ID is \fB0xFC\fR.
 .RB - t
 Display network topology using VS_SW_VER and VS_NW_INFO messages.
 This option is similar to option \fB-m\fR but provides complete network topology plus device hardware and firmware version.
-Topology is always relative to the local host, or local hosts if present.
-Powerline devices that appear on the command line are not used for this operation.
+Topology is relative to the queried powerline device(s) given on the command line. If no device is given explicitly,
+then it is tried to determine all local devices (you can also use \fBlocal\fR instead).
+However, this can fail if you have the local powerline device(s) not directly connected but via a switch which
+does not broadcast the Qualcomm Atheros vendor specific Local Management Address (LMA) to all ports.
 
 .TP
-.RB - v 
+.RB - v
 Enter verbose mode.
 All Etherenet frames sent or received by the program are displayed on stdout.
 


### PR DESCRIPTION
In a switched network, i.e. when local powerline device(s) are not
connected directly to host, then using the Local Management Address
to determine the local devices might fail due to wrong or incomplete
forwarding by the switch.

In this case it would be desirable to address the local powerline
device directly which is not possible with both tools at the moment.

This patch fixes this issue by keeping current behaviour as much as
possible and also document it in the corresponding man pages.

Signed-off-by: Michael Heimpold <michael.heimpold@i2se.com>