### PR TITLE
Fix parsing of command line options for {amp,int6k,plc}rate and int6k…

### DIFF
--- a/plc/amprate.c
+++ b/plc/amprate.c
@@ -288,6 +288,7 @@ int main (int argc, char const * argv [])
 			break;
 		case 'd':
 			plc.timer = (unsigned)(uintspec (optarg, 1, 60));
+			break;
 		case 'e':
 			dup2 (STDOUT_FILENO, STDERR_FILENO);
 			break;

--- a/plc/int6krate.c
+++ b/plc/int6krate.c
@@ -282,6 +282,7 @@ int main (int argc, char const * argv [])
 			break;
 		case 'd':
 			plc.timer = (unsigned)(uintspec (optarg, 1, 60));
+			break;
 		case 'e':
 			dup2 (STDOUT_FILENO, STDERR_FILENO);
 			break;

--- a/plc/plcrate.c
+++ b/plc/plcrate.c
@@ -282,6 +282,7 @@ int main (int argc, char const * argv [])
 			break;
 		case 'd':
 			plc.timer = (unsigned)(uintspec (optarg, 1, 60));
+			break;
 		case 'e':
 			dup2 (STDOUT_FILENO, STDERR_FILENO);
 			break;

--- a/serial/int6kbaud.c
+++ b/serial/int6kbaud.c
@@ -381,6 +381,7 @@ int main (int argc, char const * argv [])
 		case 'm':
 			_setbits (uart.flags, UART_ATBR);
 			uart.mode = (byte)(uintspec (synonym (optarg, modes, MODES), 0, UCHAR_MAX));
+			break;
 		case 'P':
 			_setbits (uart.flags, UART_ATBR);
 			uart.parity = (byte)(uintspec (synonym (optarg, paritybits, PARITYBITS), 0, UCHAR_MAX));


### PR DESCRIPTION
…baud

When compiling with -Wimplicit-fallthrough= I noticed that compiler
warned about several statements which may fall through. After inspection
I'm sure that falling through is not desired behavior but simply
a break is missing in all cases.

So let's fix the unwanted side-effects which occur at the moment
when using the affected command line options.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>