### PR TITLE
Add FreeBSD support, as well as fix a few bugs found while compiling in FreeBSD

### DIFF
--- a/README
+++ b/README
@@ -77,7 +77,9 @@ TO INSTALL
 7. Add page toolkit.html to browser favorites.
 
 Note: 'make' is assumed to be the GNU make command (often available
-      under the name 'gmake').
+      under the name 'gmake'). Also, gcc is assumed to be the system
+      default compiler. On BSD systems, this may be clang. If so,
+      replace 'gcc' with 'clang' in the top level make.def file.
 
 TO UNINSTALL
 ------------
@@ -87,7 +89,9 @@ TO UNINSTALL
 3. Remove all package files using "rm -r *".
 
 Note: 'make' is assumed to be the GNU make command (often available
-      under the name 'gmake').
+      under the name 'gmake'). Also, gcc is assumed to be the system
+      default compiler. On BSD systems, this may be clang. If so,
+      replace 'gcc' with 'clang' in the top level make.def file.
 
 CONTRIBUTORS
 ------------

--- a/ether/channel.c
+++ b/ether/channel.c
@@ -89,7 +89,7 @@ struct channel channel =
 
 #if defined (__linux__)
 
-#elif defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__)
+#elif defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__) || defined (__FreeBSD__)
 
 	(struct bpf *) (0),
 

--- a/ether/channel.h
+++ b/ether/channel.h
@@ -172,7 +172,7 @@ typedef struct channel
 
 	struct bpf
 	{
-		signed bpf_length;
+		unsigned bpf_length;
 		uint8_t * bpf_buffer;
 		uint8_t * bpf_bp;
 		signed bpf_bufused;

--- a/ether/channel.h
+++ b/ether/channel.h
@@ -76,7 +76,7 @@
  *   sort out the raw socket mess;
  *--------------------------------------------------------------------*/
 
-#if defined (__linux__) || defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__)
+#if defined (__linux__) || defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__) || defined (__FreeBSD__)
 #       ifdef WINPCAP
 #               error "Don't enable winpcap on Linux. It won't work."
 #               endif
@@ -117,7 +117,7 @@
 #elif defined (__APPLE__)
 #       define CHANNEL_ETHDEVICE "en0"
 #       define CHANNEL_BPFDEVICE "/dev/bpf%d"
-#elif defined (__OpenBSD__) || defined(__NetBSD__)
+#elif defined (__OpenBSD__) || defined(__NetBSD__) || defined(__FreeBSD__)
 #       define CHANNEL_ETHDEVICE "bce0"
 #       define CHANNEL_BPFDEVICE "/dev/bpf%d"
 #else
@@ -168,7 +168,7 @@ typedef struct channel
 
 #if defined (__linux__)
 
-#elif defined (__APPLE__) || defined (__OpenBSD__) || defined(__NetBSD__)
+#elif defined (__APPLE__) || defined (__OpenBSD__) || defined(__NetBSD__) || defined(__FreeBSD__)
 
 	struct bpf
 	{

--- a/ether/closechannel.c
+++ b/ether/closechannel.c
@@ -70,7 +70,7 @@ signed closechannel (struct channel const * channel)
 
 	return (close (channel->fd));
 
-#elif defined (__APPLE__) || (__OpenBSD__) || defined (__NetBSD__)
+#elif defined (__APPLE__) || (__OpenBSD__) || defined (__NetBSD__) || defined (__FreeBSD__)
 
 	free (channel->bpf->bpf_buffer);
 	free (channel->bpf);

--- a/ether/ether.h
+++ b/ether/ether.h
@@ -39,6 +39,15 @@
 #       include <netinet/if_ether.h>
 #       include <net/bpf.h>
 #       include <fcntl.h>
+#elif defined (__FreeBSD__)
+#       include <sys/ioctl.h>
+#       include <sys/types.h>
+#       include <sys/socket.h>
+#       include <net/if.h>
+#       include <net/ethernet.h>
+#       include <netinet/in.h>
+#       include <sys/time.h>
+#       include <net/bpf.h>
 #elif defined (WIN32)
 #       if defined (WINPCAP)
 #               include <pcap.h>

--- a/ether/gethwaddr.c
+++ b/ether/gethwaddr.c
@@ -158,7 +158,7 @@ int gethwaddr (void * memory, char const * device)
 	}
 	freeifaddrs (ifaddrs);
 
-#elif defined (__OpenBSD__) || defined(__NetBSD__)
+#elif defined (__OpenBSD__) || defined(__NetBSD__) || defined (__FreeBSD__)
 
 #include <ifaddrs.h>
 #include <net/if_dl.h>

--- a/ether/getifname.c
+++ b/ether/getifname.c
@@ -74,7 +74,7 @@ char * getifname (signed index)
 
 #if defined (__linux__)
 
-#elif defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__)
+#elif defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__) || defined (__FreeBSD__)
 
 #elif defined (WINPCAP) || defined (LIBPCAP)
 

--- a/ether/hostnics.c
+++ b/ether/hostnics.c
@@ -69,7 +69,7 @@
 #	include <net/if.h>
 #	include <netpacket/packet.h>
 #	include <ifaddrs.h>
-#elif defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__)
+#elif defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__) || defined (__FreeBSD__)
 #	include <sys/types.h>
 #	include <sys/socket.h>
 #	include <net/if.h>
@@ -146,7 +146,7 @@ unsigned hostnics (struct nic nics [], unsigned size)
 	}
 	close (fd);
 
-#elif defined (__linux__) || defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__)
+#elif defined (__linux__) || defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__) || defined (__FreeBSD__)
 
 /*
  *	generic (POSIX) method for unix-like systems;
@@ -195,7 +195,7 @@ unsigned hostnics (struct nic nics [], unsigned size)
 				memcpy (nic->ethernet, LLADDR (sockaddr_ll), sizeof (nic->ethernet));
 			}
 
-#elif defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__)
+#elif defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__) || defined (__FreeBSD__)
 
 			if (ifaddr->ifa_addr->sa_family == AF_LINK)
 			{

--- a/ether/openchannel.c
+++ b/ether/openchannel.c
@@ -70,7 +70,7 @@
 #	include <sys/stat.h>
 #	include <fcntl.h>
 #	include <stdlib.h>
-#elif defined (__OpenBSD__) || defined (__NetBSD__)
+#elif defined (__OpenBSD__) || defined (__NetBSD__) || defined (__FreeBSD__)
 #	include <sys/ioctl.h>
 #	include <sys/stat.h>
 #	include <sys/types.h>
@@ -87,7 +87,7 @@
 #include "../tools/flags.h"
 #include "../tools/error.h"
 
-#if defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__)
+#if defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__) || defined (__FreeBSD__)
 #	include "../ether/gethwaddr.c"
 #endif
 
@@ -296,7 +296,7 @@ signed openchannel (struct channel * channel)
 		}
 	};
 
-#if defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__)
+#if defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__) || defined (__FreeBSD__)
 
 	struct ifreq ifreq;
 	struct timeval timeval;
@@ -363,6 +363,14 @@ signed openchannel (struct channel * channel)
 
 	state = BPF_DIRECTION_OUT;
 	if (ioctl (channel->fd, BIOCSDIRFILT, &state) == -1)
+	{
+		error (0, errno, "Can't hide outgoing frames");
+	}
+
+#elif defined (__FreeBSD__)
+
+	state = BPF_D_IN;
+	if (ioctl (channel->fd, BIOCSDIRECTION, &state) == -1)
 	{
 		error (0, errno, "Can't hide outgoing frames");
 	}

--- a/ether/pcapdevs.c
+++ b/ether/pcapdevs.c
@@ -62,7 +62,7 @@
 
 #if defined (__linux__)
 #elif defined (__APPLE__)
-#elif defined (__OpenBSD__) || defined (__NetBSD__)
+#elif defined (__OpenBSD__) || defined (__NetBSD__) || defined (__FreeBSD__)
 #	include <sys/types.h>
 #	include <sys/socket.h>
 #	include <net/if.h>

--- a/ether/readpacket.c
+++ b/ether/readpacket.c
@@ -131,7 +131,7 @@ ssize_t readpacket (struct channel const * channel, void * memory, ssize_t exten
 		}
 	}
 
-#elif defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__)
+#elif defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__) || defined (__FreeBSD__)
 
 	struct bpf_hdr * bpf_packet;
 	struct bpf * bpf = channel->bpf;;

--- a/ether/sendpacket.c
+++ b/ether/sendpacket.c
@@ -77,7 +77,7 @@ ssize_t sendpacket (struct channel const * channel, void * memory, ssize_t exten
 
 	extent = sendto (channel->fd, memory, extent, 0, (struct sockaddr *) (0), (socklen_t) (0));
 
-#elif defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__)
+#elif defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__) || defined (__FreeBSD__)
 
 	extent = write (channel->fd, memory, extent);
 

--- a/plc/PLCHostBoot.c
+++ b/plc/PLCHostBoot.c
@@ -81,7 +81,7 @@ static signed opensocket (char const * socketname)
 	struct sockaddr_un sockaddr_un =
 	{
 
-#if defined (__OpenBSD__) || defined (__NetBSD__)
+#if defined (__OpenBSD__) || defined (__NetBSD__) || defined (__FreeBSD__)
 
 		0,
 
@@ -92,7 +92,7 @@ static signed opensocket (char const * socketname)
 	};
 	strncpy (sockaddr_un.sun_path, socketname, sizeof (sockaddr_un.sun_path));
 
-#if defined (__OpenBSD__) || defined (__NetBSD__)
+#if defined (__OpenBSD__) || defined (__NetBSD__) || defined (__FreeBSD__)
 
 	sockaddr_un.sun_len = SUN_LEN (&sockaddr_un);
 

--- a/plc/plc.c
+++ b/plc/plc.c
@@ -293,7 +293,7 @@ struct plc plc =
 	PLC_FLAGS
 };
 
-#if defined (__linux__) || defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__)
+#if defined (__linux__) || defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__) || defined (__FreeBSD__)
 #define RANDOMIZE_COOKIE 1
 #endif
 

--- a/plc/plcdevs.c
+++ b/plc/plcdevs.c
@@ -144,7 +144,7 @@ static void enumerate (struct channel * channel, struct nic nic [], unsigned siz
 
 		printf (" %d", nic->ifindex);
 
-#elif defined (__linux__) || defined (__OpenBSD__) || defined (__NetBSD__) || defined (__APPLE__)
+#elif defined (__linux__) || defined (__OpenBSD__) || defined (__NetBSD__) || defined (__APPLE__) || defined (__FreeBSD__)
 
 		printf (" %s", nic->ifname);
 

--- a/plc/plchostd.c
+++ b/plc/plchostd.c
@@ -252,7 +252,7 @@ static signed opensocket (char const * socketname)
 	struct sockaddr_un sockaddr_un =
 	{
 
-#if defined (__OpenBSD__) || defined (__NetBSD__) || defined (__APPLE__)
+#if defined (__OpenBSD__) || defined (__NetBSD__) || defined (__APPLE__) || defined (__FreeBSD__)
 
 		0,
 
@@ -263,7 +263,7 @@ static signed opensocket (char const * socketname)
 	};
 	strncpy (sockaddr_un.sun_path, socketname, sizeof (sockaddr_un.sun_path));
 
-#if defined (__OpenBSD__) || defined (__NetBSD__) || defined (__APPLE__)
+#if defined (__OpenBSD__) || defined (__NetBSD__) || defined (__APPLE__) || defined (__FreeBSD__)
 
 	sockaddr_un.sun_len = SUN_LEN (&sockaddr_un);
 

--- a/plc/plchostd2.c
+++ b/plc/plchostd2.c
@@ -231,7 +231,7 @@ static signed opensocket (char const * socketname)
 	struct sockaddr_un sockaddr_un =
 	{
 
-#if defined (__OpenBSD__) || defined (__NetBSD__) || defined (__APPLE__)
+#if defined (__OpenBSD__) || defined (__NetBSD__) || defined (__APPLE__) || defined (__FreeBSD__)
 
 		0,
 
@@ -242,7 +242,7 @@ static signed opensocket (char const * socketname)
 	};
 	strncpy (sockaddr_un.sun_path, socketname, sizeof (sockaddr_un.sun_path));
 
-#if defined (__OpenBSD__) || defined (__NetBSD__) || defined (__APPLE__)
+#if defined (__OpenBSD__) || defined (__NetBSD__) || defined (__APPLE__) || defined (__FreeBSD__)
 
 	sockaddr_un.sun_len = SUN_LEN (&sockaddr_un);
 

--- a/serial/int6kbaud.c
+++ b/serial/int6kbaud.c
@@ -63,7 +63,7 @@
 #	include <termios.h>
 #elif defined (__APPLE__)
 #	include <termios.h>
-#elif defined (__OpenBSD__) || defined (__NetBSD__)
+#elif defined (__OpenBSD__) || defined (__NetBSD__) || defined (__FreeBSD__)
 #	include <termios.h>
 #else
 #error "Unknown Environment"

--- a/serial/int6kuart.c
+++ b/serial/int6kuart.c
@@ -64,7 +64,7 @@
 #	include <net/ethernet.h>
 #elif defined (__APPLE__)
 #	include <net/ethernet.h>
-#elif defined (__OpenBSD__) || defined (__NetBSD__)
+#elif defined (__OpenBSD__) || defined (__NetBSD__) || defined (__FreeBSD__)
 #	include <sys/socket.h>
 #	include <net/if.h>
 #	include <net/if_arp.h>

--- a/serial/openport.c
+++ b/serial/openport.c
@@ -79,7 +79,7 @@
 #elif defined (__APPLE__)
 #	include <termios.h>
 #	include <net/ethernet.h>
-#elif defined (__OpenBSD__) || defined (__NetBSD__)
+#elif defined (__OpenBSD__) || defined (__NetBSD__) || defined (__FreeBSD__)
 #	include <termios.h>
 #else
 #error "Unknown Environment"

--- a/serial/ptsctl.c
+++ b/serial/ptsctl.c
@@ -63,7 +63,7 @@
 #	include <termios.h>
 #elif defined (__APPLE__)
 #	include <termios.h>
-#elif defined (__OpenBSD__) || defined (__NetBSD__)
+#elif defined (__OpenBSD__) || defined (__NetBSD__) || defined (__FreeBSD__)
 #	include <termios.h>
 #elif defined (WIN32)
 #	include <windows.h>

--- a/serial/weeder.c
+++ b/serial/weeder.c
@@ -63,7 +63,7 @@
 #	include <termios.h>
 #elif defined (__APPLE__)
 #	include <termios.h>
-#elif defined (__OpenBSD__) || defined (__NetBSD__)
+#elif defined (__OpenBSD__) || defined (__NetBSD__) || defined (__FreeBSD__)
 #	include <termios.h>
 #elif defined (WIN32)
 #	include <windows.h>

--- a/tools/endian.h
+++ b/tools/endian.h
@@ -55,6 +55,9 @@
 #       include <libkern/OSByteOrder.h>
 #elif defined (__OpenBSD__)
 #       include <sys/types.h>
+#elif defined (__FreeBSD__)
+#       include <sys/types.h>
+#       include <sys/endian.h>
 #elif defined (__NetBSD__)
 #       include <sys/types.h>
 #       include <machine/bswap.h>
@@ -169,7 +172,7 @@ uint64_t __bswap_64 (uint64_t x);
 #define __bswap_32(x) swap32(x)
 #define __bswap_64(x) swap64(x)
 
-#elif defined (__NetBSD__)
+#elif defined (__NetBSD__) || defined(__FreeBSD__)
 
 #define __bswap_16(x) bswap16(x)
 #define __bswap_32(x) bswap32(x)

--- a/tools/flags.h
+++ b/tools/flags.h
@@ -24,24 +24,24 @@
 #define _bits(object) (sizeof (object) << 3)
 #define _getbits(map,pos,cnt) (((map)>>((pos)-(cnt)+1))&~(~(0)<<(cnt)))
 
-#define _bitmask(bits) ~(~(0) << bits)
+#define _bitmask(bits) (~(~(0) << bits))
 
-#define _setbits(flag,mask) flag |=  (mask)
-#define _clrbits(flag,mask) flag &= ~(mask)
-#define _toggle(flag,mask)  flag = ~(flag) & ~(mask)
+#define _setbits(flag,mask) (flag |=  (mask))
+#define _clrbits(flag,mask) (flag &= ~(mask))
+#define _toggle(flag,mask)  (flag = ~(flag) & ~(mask))
 
-#define _anyset(flag,mask) ((flag) & (mask)) != (0)
-#define _anyclr(flag,mask) ((flag) & (mask)) != (mask)
-#define _allset(flag,mask) ((flag) & (mask)) == (mask)
-#define _allclr(flag,mask) ((flag) & (mask)) == (0)
+#define _anyset(flag,mask) (((flag) & (mask)) != (0))
+#define _anyclr(flag,mask) (((flag) & (mask)) != (mask))
+#define _allset(flag,mask) (((flag) & (mask)) == (mask))
+#define _allclr(flag,mask) (((flag) & (mask)) == (0))
 
 // #define _notset(flag,mask) ((flag) & (mask)) == (0)
 
-#define _anybits(flag,mask) ((flag) & (mask)) != (0)
-#define _allbits(flag,mask) ((flag) & (mask)) == (mask)
+#define _anybits(flag,mask) (((flag) & (mask)) != (0))
+#define _allbits(flag,mask) (((flag) & (mask)) == (mask))
 
-#define _clean(flag,mask) ((flag) & ~(mask)) == (0)
-#define _dirty(flag,mask) ((flag) & ~(mask)) != (0)
+#define _clean(flag,mask) (((flag) & ~(mask)) == (0))
+#define _dirty(flag,mask) (((flag) & ~(mask)) != (0))
 
 /*====================================================================*
  *

--- a/tools/types.h
+++ b/tools/types.h
@@ -40,6 +40,9 @@
 #elif defined (__OpenBSD__) || defined (__NetBSD__)
 	#define SIZE_T_SPEC "%zu"
 	#define OFF_T_SPEC "%lld"
+#elif defined(__FreeBSD__)
+	#define SIZE_T_SPEC "%zu"
+	#define OFF_T_SPEC "%ld"
 #elif defined (__linux__)
 	#define SIZE_T_SPEC "%zu"
 	#define OFF_T_SPEC "%ld"


### PR DESCRIPTION
Add FreeBSD support. In most cases, this was just adding a "|| defined (__FreeBSD__)" next to existing BSD related compile checks.

Add a few missing parenthesis around some macro bodies, which were noticed by the default FreeBSD clang compiler.

Switch the bpf_length to unsigned, instead of signed. The BPF man page for all supported OSes indicates it should be unsigned, and as a buffer length, unsigned makes the most sense.

Fixes #122.