### PR TITLE
plc/plc.h: fix build with gcc 10

### DIFF
--- a/plc/plc.h
+++ b/plc/plc.h
@@ -484,7 +484,7 @@ signed WriteParameters2 (struct plc *, unsigned module, const struct nvm_header2
 #pragma pack (push,1)
 #endif
 
-struct __packed plcproperty
+typedef struct __packed plcproperty
 
 {
 	uint8_t PROP_OPTION;


### PR DESCRIPTION
Drop plcproperty from plc/plc.h to avoid the following build failure with gcc 10 (which defaults to -fno-common):

```
/home/buildroot/autobuild/run/instance-3/output-1/host/lib/gcc/arm-buildroot-linux-gnueabihf/10.2.0/../../../../arm-buildroot-linux-gnueabihf/bin/ld: rules.o:(.bss+0x0): multiple definition of `plcproperty'; pibruin.o:(.bss+0x0): first defined here
```

Fixes:
 - http://autobuild.buildroot.org/results/6b3064b64dea3d4aaf219f787429c25918101483

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>