### PR TITLE
Add missing typedef for plcproperty

### DIFF
--- a/plc/plc.h
+++ b/plc/plc.h
@@ -484,7 +484,7 @@ signed WriteParameters2 (struct plc *, unsigned module, const struct nvm_header2
 #pragma pack (push,1)
 #endif
 
-struct __packed plcproperty
+typedef struct __packed plcproperty
 
 {
 	uint8_t PROP_OPTION;


### PR DESCRIPTION
Compilation with Ubuntu 20.10 uncovered the following linker problem:
/usr/bin/ld: rules.o:(.bss+0x0): multiple definition of `plcproperty'; pibruin.o:(.bss+0x0): first defined here
/usr/bin/ld: ParseRule.o:(.bss+0x0): multiple definition of `plcproperty'; pibruin.o:(.bss+0x0): first defined here
/usr/bin/ld: piblock.o:(.bss+0x0): multiple definition of `plcproperty'; pibruin.o:(.bss+0x0): first defined here
/usr/bin/ld: ruledump.o:(.bss+0x0): multiple definition of `plcproperty'; pibruin.o:(.bss+0x0): first defined here
collect2: error: ld returned 1 exit status

When looking at the include file plc.h, we find that the typedef keyword
is missing which in turn results in a variable declaration - which is
usually not wanted in header files.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>