### PR TITLE
Fix chipset reporting (fixes #151)

### DIFF
--- a/plc/PLCNetworkInfo.c
+++ b/plc/PLCNetworkInfo.c
@@ -72,6 +72,7 @@ signed PLCNetworkInfo (struct plc * plc)
 
 {
 	signed status;
+	uint32_t ident;
 	struct channel * channel = (struct channel *)(plc->channel);
 	struct message * message = (struct message *)(plc->message);
 
@@ -123,7 +124,7 @@ signed PLCNetworkInfo (struct plc * plc)
 		Failure (plc, "Device will not start");
 		return (-1);
 	}
-	chipset (confirm);
+	chipset (confirm, & ident);
 	if ((plc->hardwareID = confirm->MDEVICEID) < CHIPSET_AR7400)
 	{
 		status = NetInfo1 (plc);

--- a/plc/PLCPhyRates.c
+++ b/plc/PLCPhyRates.c
@@ -72,6 +72,7 @@ signed PLCPhyRates (struct plc * plc)
 
 {
 	signed status;
+	uint32_t ident;
 	struct channel * channel = (struct channel *)(plc->channel);
 	struct message * message = (struct message *)(plc->message);
 
@@ -123,7 +124,7 @@ signed PLCPhyRates (struct plc * plc)
 		Failure (plc, "Device will not start");
 		return (-1);
 	}
-	chipset (confirm);
+	chipset (confirm, & ident);
 	if ((plc->hardwareID = confirm->MDEVICEID) < CHIPSET_AR7400)
 	{
 		status = PhyRates1 (plc);

--- a/plc/PLCTopology.c
+++ b/plc/PLCTopology.c
@@ -121,7 +121,7 @@ static signed PLCPlatform (struct channel * channel, struct plcstation * plcstat
 			{
 				uint32_t ident;
 				chipset (confirm, & ident);
-				strncpy (plcstation->hardware, chipsetname (confirm->MDEVICE), sizeof (plcstation->hardware));
+				strncpy (plcstation->hardware, chipsetname_by_ident (ident, confirm->MDEVICE), sizeof (plcstation->hardware));
 				strncpy (plcstation->firmware, confirm->MSTRING, sizeof (plcstation->firmware));
 				return (0);
 			}

--- a/plc/PLCTopology.c
+++ b/plc/PLCTopology.c
@@ -119,7 +119,8 @@ static signed PLCPlatform (struct channel * channel, struct plcstation * plcstat
 		{
 			if (!UnwantedMessage (&message, packetsize, 0, (VS_SW_VER | MMTYPE_CNF)))
 			{
-				chipset (confirm);
+				uint32_t ident;
+				chipset (confirm, & ident);
 				strncpy (plcstation->hardware, chipsetname (confirm->MDEVICE), sizeof (plcstation->hardware));
 				strncpy (plcstation->firmware, confirm->MSTRING, sizeof (plcstation->firmware));
 				return (0);

--- a/plc/Platform.c
+++ b/plc/Platform.c
@@ -107,7 +107,7 @@ signed Platform (struct channel * channel, const uint8_t device [])
 			{
 				uint32_t ident;
 				chipset (confirm, & ident);
-				printf (" %s", chipsetname (confirm->MDEVICEID));
+				printf (" %s", chipsetname_by_ident (ident, confirm->MDEVICEID));
 				printf (" %s", confirm->MVERSION);
 				return (0);
 			}

--- a/plc/Platform.c
+++ b/plc/Platform.c
@@ -105,7 +105,8 @@ signed Platform (struct channel * channel, const uint8_t device [])
 		{
 			if (!UnwantedMessage (&message, packetsize, 0, (VS_SW_VER | MMTYPE_CNF)))
 			{
-				chipset (confirm);
+				uint32_t ident;
+				chipset (confirm, & ident);
 				printf (" %s", chipsetname (confirm->MDEVICEID));
 				printf (" %s", confirm->MVERSION);
 				return (0);

--- a/plc/VersionInfo1.c
+++ b/plc/VersionInfo1.c
@@ -108,12 +108,13 @@ signed VersionInfo1 (struct plc * plc)
 	}
 	while (ReadMME (plc, 0, (VS_SW_VER | MMTYPE_CNF)) > 0)
 	{
+		uint32_t ident;
 		if (confirm->MSTATUS)
 		{
 			Failure (plc, PLC_WONTDOIT);
 			continue;
 		}
-		chipset (confirm);
+		chipset (confirm, & ident);
 		Display (plc, "%s %s", chipsetname (confirm->MDEVICEID), confirm->MVERSION);
 	}
 	return (0);

--- a/plc/VersionInfo1.c
+++ b/plc/VersionInfo1.c
@@ -115,7 +115,7 @@ signed VersionInfo1 (struct plc * plc)
 			continue;
 		}
 		chipset (confirm, & ident);
-		Display (plc, "%s %s", chipsetname (confirm->MDEVICEID), confirm->MVERSION);
+		Display (plc, "%s %s", chipsetname_by_ident (ident, confirm->MDEVICEID), confirm->MVERSION);
 	}
 	return (0);
 }

--- a/plc/VersionInfo2.c
+++ b/plc/VersionInfo2.c
@@ -114,6 +114,7 @@ signed VersionInfo2 (struct plc * plc)
 	}
 	while (ReadMME (plc, 0, (VS_SW_VER | MMTYPE_CNF)) > 0)
 	{
+		uint32_t ident;
 
 #if 0
 
@@ -135,7 +136,7 @@ signed VersionInfo2 (struct plc * plc)
 			Failure (plc, PLC_WONTDOIT);
 			continue;
 		}
-		chipset (confirm);
+		chipset (confirm, & ident);
 		Display (plc, "%s %s", chipsetname (confirm->MDEVICE_CLASS), confirm->MVERSION);
 	}
 	return (0);

--- a/plc/VersionInfo2.c
+++ b/plc/VersionInfo2.c
@@ -137,7 +137,7 @@ signed VersionInfo2 (struct plc * plc)
 			continue;
 		}
 		chipset (confirm, & ident);
-		Display (plc, "%s %s", chipsetname (confirm->MDEVICE_CLASS), confirm->MVERSION);
+		Display (plc, "%s %s", chipsetname_by_ident (ident, confirm->MDEVICE_CLASS), confirm->MVERSION);
 	}
 	return (0);
 }

--- a/plc/WaitForStart.c
+++ b/plc/WaitForStart.c
@@ -135,7 +135,8 @@ signed WaitForStart (struct plc * plc, char string [], size_t length)
 		}
 		if (plc->packetsize)
 		{
-			chipset (confirm);
+			uint32_t ident;
+			chipset (confirm, & ident);
 			plc->hardwareID = confirm->MDEVICEID;
 			memcpy (channel->peer, request->ethernet.OSA, sizeof (channel->peer));
 			if (confirm->MVERLENGTH > length)

--- a/plc/chipset.c
+++ b/plc/chipset.c
@@ -324,9 +324,19 @@ void chipset (void const * memory)
 			CHIPSET_QCA7451A0
 		},
 		{
+			0x001CFC00,
+			0x20,
+			CHIPSET_QCA7420A0
+		},
+		{
 			0x001CFCFC,
 			0x20,
 			CHIPSET_QCA7420A0
+		},
+		{
+			0x001B587C,
+			0x22,
+			CHIPSET_QCA7005A0
 		},
 		{
 			0x001B58EC,

--- a/plc/chipset.c
+++ b/plc/chipset.c
@@ -134,6 +134,48 @@ char const * chipsetname (uint8_t MDEVICE_CLASS)
 
 /*====================================================================*
  *
+ *   char const * chipsetname_by_ident (uint32_t ident, uint8_t chipset)
+ *
+ *   chipset.h
+ *
+ *   return the ASCII name string associated with the IDENT (aka STRAP)
+ *   field in the VS_SW_VER.CNF message;
+ *   in case of unknown value, fallback using chipsetname function
+ *
+ *--------------------------------------------------------------------*/
+
+char const * chipsetname_by_ident (uint32_t ident, uint8_t chipset)
+{
+	static const struct _type_ chipname [] =
+	{
+		{ 0x00000042, "INT6000" },
+		{ 0x00006300, "INT6300" },
+#if 0
+		/* don't list these two here since we would need MDEVICE_CLASS
+		 * (aka our chipset parameter) to differentiate; instead we rely
+		 *  on older chipsetname function to handle it during fallback...
+		 */
+		{ 0x00006400, " AR6405" },
+		{ 0x00006400, "INT6400" },
+#endif
+		{ 0x00007400, " AR7400" },
+		{ 0x001B587C, "QCA7005" },
+		{ 0x001B589C, "QCA7000" },
+		{ 0x001B58BC, "QCA6411" },
+		{ 0x001B58DC, "QCA7000" },
+		{ 0x001B58EC, "QCA6410" },
+		{ 0x001CFC00, "QCA7420" },
+		{ 0x001CFCFC, "QCA7420" },
+		{ 0x001D4C00, "QCA7500" },
+		{ 0x001D4C0F, "QCA7500" },
+		{ 0x0E001D1A, "QCA7451" },
+		{ 0x0F001D1A, "QCA7450" },
+	};
+	return (typename (chipname, SIZEOF (chipname), ident, chipsetname (chipset)));
+}
+
+/*====================================================================*
+ *
  *   void chipset (void const * memory, uint32_t * ident);
  *
  *   chipset.h

--- a/plc/chipset.c
+++ b/plc/chipset.c
@@ -134,12 +134,14 @@ char const * chipsetname (uint8_t MDEVICE_CLASS)
 
 /*====================================================================*
  *
- *   void chipset (void const * memory);
+ *   void chipset (void const * memory, uint32_t * ident);
  *
- *   Chipset.h
+ *   chipset.h
  *
  *   replace VS_SW_VER message MDEVICE_CLASS field with correct value;
  *   the MDEVICE_CLASS field was named MDEVICEID at one time;
+ *   while at save the ident field to given (since the offset varies,
+ *   it can be used by caller later more easily);
  *
  *   Atheros chipsets are identified by code in the VS_SW_VER vendor
  *   specific management message; the chipset [] vector translates a
@@ -171,7 +173,7 @@ char const * chipsetname (uint8_t MDEVICE_CLASS)
  *
  *--------------------------------------------------------------------*/
 
-void chipset (void const * memory)
+void chipset (void const * memory, uint32_t * ident)
 
 {
 
@@ -378,6 +380,7 @@ void chipset (void const * memory)
 				continue;
 			}
 			confirm->MDEVICE_CLASS = bootrom [chip].DEVICE;
+			* ident = LE32TOH (chipinfo->STRAP);
 			return;
 		}
 	}
@@ -392,24 +395,28 @@ void chipset (void const * memory)
 			if (firmware [chip].STRAP < CHIPSET_PANTHER_LYNX)
 			{
 				confirm->MDEVICE_CLASS = firmware [chip].DEVICE;
+				* ident = LE32TOH (chipinfo->STRAP);
 				return;
 			}
 			chipinfo = (struct chipinfo *) (& confirm->MVERSION [64]);
 			if (firmware [chip].STRAP == LE32TOH (chipinfo->STRAP))
 			{
 				confirm->MDEVICE_CLASS = firmware [chip].DEVICE;
+				* ident = LE32TOH (chipinfo->STRAP);
 				return;
 			}
 			chipinfo = (struct chipinfo *) (& confirm->MVERSION [128]);
 			if (firmware [chip].STRAP == LE32TOH (chipinfo->STRAP))
 			{
 				confirm->MDEVICE_CLASS = firmware [chip].DEVICE;
+				* ident = LE32TOH (chipinfo->STRAP);
 				return;
 			}
 			chipinfo = (struct chipinfo *) (& confirm->MVERSION [253]);
 			if (firmware [chip].STRAP == LE32TOH (chipinfo->STRAP))
 			{
 				confirm->MDEVICE_CLASS = firmware [chip].DEVICE;
+				* ident = LE32TOH (chipinfo->STRAP);
 				return;
 			}
 		}

--- a/plc/chipset.h
+++ b/plc/chipset.h
@@ -103,6 +103,7 @@
  *--------------------------------------------------------------------*/
 
 char const * chipsetname (uint8_t chipset);
+char const * chipsetname_by_ident (uint32_t ident, uint8_t chipset);
 void chipset (void const * memory, uint32_t * ident);
 
 /*====================================================================*

--- a/plc/chipset.h
+++ b/plc/chipset.h
@@ -103,7 +103,7 @@
  *--------------------------------------------------------------------*/
 
 char const * chipsetname (uint8_t chipset);
-void chipset (void const * memory);
+void chipset (void const * memory, uint32_t * ident);
 
 /*====================================================================*
  *

--- a/plc/plc.h
+++ b/plc/plc.h
@@ -317,7 +317,7 @@ PLC;
  *  fixer-upper functions that compensate for errors and omissions;
  *--------------------------------------------------------------------*/
 
-void chipset (void const * memory);
+void chipset (void const * memory, uint32_t * ident);
 char const * chipsetname (uint8_t chipset);
 
 /*====================================================================*


### PR DESCRIPTION
As described in #151, reporting the chipset name is not working as expected - at least as I would expect.

This PR tries solves this issue by introducing a new function which not only considers the MCLASS field
as older chipsetname function does, but by relying on the IDENT field in the response MME.

Signed-off-by: Michael Heimpold <michael.heimpold@in-tech.com>
