### PR TITLE
Typo mistake fix on chkpib

### DIFF
--- a/pib/chkpib.1
+++ b/pib/chkpib.1
@@ -83,7 +83,7 @@ Remember that "\fBlooking good\fR" does not mean "\fBis good\fR".
 
 .PP
 The next example reads three files and displays selected information about each one because option \fB-v\fR is present.
-Ov course, program output could be piped to a file and used for documentation purposes.
+Of course, program output could be piped to a file and used for documentation purposes.
 
 .PP
    # chkpib -v INT6400.pib AR7400.pib AR7420.pib


### PR DESCRIPTION
A small typo mistake has been fixed on chkpib.1 file.