### PR TITLE
tools/types.h: drop bool mess - include stdbool.h instead

### DIFF
--- a/tools/types.h
+++ b/tools/types.h
@@ -23,6 +23,7 @@
  *--------------------------------------------------------------------*/
 
 #include <stdint.h>
+#include <stdbool.h>
 
 /*====================================================================*
  *   constants;
@@ -65,33 +66,6 @@ error "Unknown environment."
 typedef signed errno_t;
 typedef signed signo_t;
 typedef unsigned char byte;
-
-/*====================================================================*
- *   define C++ style true and false for use in standard C programs;
- *--------------------------------------------------------------------*/
-
-#ifndef __cplusplus
-
-#ifdef false
-# undef false
-#endif
-#ifdef true
-# undef true
-#endif
-#ifdef bool
-# undef bool
-#endif
-
-typedef enum
-
-{
-	false,
-	true
-}
-
-bool;
-
-#endif
 
 /*====================================================================*
  *   cope with structure packing vagaries;


### PR DESCRIPTION
Instead of trying to deal with bool stuff ourselv, just rely on the stdbool.h and use it instead.

This fixes compilation with gcc 15 as reported in #187.