### PR TITLE
Added boundary check to numGroups to avoid buffer overflow

### DIFF
--- a/slac/evse_cm_mnbc_sound.c
+++ b/slac/evse_cm_mnbc_sound.c
@@ -153,6 +153,11 @@ signed evse_cm_mnbc_sound (struct session * session, struct channel * channel, s
 
 #endif
 
+				if (indicate->NumGroups > SLAC_GROUPS)
+				{
+					indicate->NumGroups = SLAC_GROUPS;
+				}
+				
 				for (session->NumGroups = 0; session->NumGroups < indicate->NumGroups; session->NumGroups++)
 				{
 					AAG [session->NumGroups] += indicate->AAG [session->NumGroups];

--- a/slac/pev_cm_atten_char.c
+++ b/slac/pev_cm_atten_char.c
@@ -75,6 +75,10 @@ signed pev_cm_atten_char (struct session * session, struct channel * channel, st
 			memcpy (session->EVSE_MAC, indicate->ethernet.OSA, sizeof (session->EVSE_MAC));
 			session->NUM_SOUNDS = indicate->ACVarField.NUM_SOUNDS;
 			session->NumGroups = indicate->ACVarField.ATTEN_PROFILE.NumGroups;
+			if (session->NumGroups > SLAC_GROUPS)
+			{
+				session->NumGroups = SLAC_GROUPS;
+			}
 			memcpy (session->AAG, indicate->ACVarField.ATTEN_PROFILE.AAG, indicate->ACVarField.ATTEN_PROFILE.NumGroups);
 
 #if SLAC_DEBUG


### PR DESCRIPTION
Attacker crafting HPGP packets is able to sent numGroups of size up to 255 which is higher than the expected and allocated 58 bytes for the AAG buffer.

Added a boundary trim to SLAC_GROUPS constant in the following functions:

- evse_cm_mnbc_sound
- pev_cm_atten_char