### PR TITLE
Fix some compiler warning about unaligned access

### DIFF
--- a/plc/MDUTrafficStats.c
+++ b/plc/MDUTrafficStats.c
@@ -116,6 +116,7 @@
 #define MASTER_FETCH 	(1 << 2)
 #define SLAVE_CLEAR 	(1 << 3)
 #define ETHERNET_STATS 	(1 << 4)
+#define MDU_SLAVE_BITMAP_WORDS 8
 
 /*====================================================================*
  *   variables;
@@ -335,6 +336,7 @@ signed MDUTrafficStats (struct plc * plc, uint8_t command, uint8_t session, uint
 {
 	struct channel * channel = (struct channel *)(plc->channel);
 	struct message * message = (struct message *)(plc->message);
+	uint32_t slave_bitmap [MDU_SLAVE_BITMAP_WORDS] = { 0 };
 
 #ifndef __GNUC__
 #pragma pack (push,1)
@@ -346,7 +348,7 @@ signed MDUTrafficStats (struct plc * plc, uint8_t command, uint8_t session, uint
 		struct qualcomm_hdr qualcomm;
 		uint8_t COMMAND;
 		uint8_t SESSION;
-		uint32_t SLAVE_BITMAP [8];
+		uint32_t SLAVE_BITMAP [MDU_SLAVE_BITMAP_WORDS];
 	}
 	* request = (struct vs_mdu_station_stats_request *) (message);
 	struct __packed vs_mdu_traffic_master_confirm
@@ -400,7 +402,8 @@ signed MDUTrafficStats (struct plc * plc, uint8_t command, uint8_t session, uint
 	QualcommHeader (&request->qualcomm, 0, (VS_MDU_TRAFFIC_STATS | MMTYPE_REQ));
 	request->COMMAND = command;
 	request->SESSION = session;
-	set32bitmap (request->SLAVE_BITMAP, slave);
+	set32bitmap (slave_bitmap, slave);
+	memcpy (request->SLAVE_BITMAP, slave_bitmap, sizeof (slave_bitmap));
 	plc->packetsize = sizeof (* request);
 	if (SendMME (plc) <= 0)
 	{
@@ -451,4 +454,3 @@ signed MDUTrafficStats (struct plc * plc, uint8_t command, uint8_t session, uint
 
 
 #endif
-

--- a/plc/plcfwd.c
+++ b/plc/plcfwd.c
@@ -167,6 +167,29 @@ item;
 #pragma pack (pop)
 #endif
 
+static uint8_t * EncodeVLANIDs (uint8_t * memory, struct item const * list, unsigned items)
+
+{
+	while (items--)
+	{
+		uint16_t value;
+		unsigned count;
+		memcpy (memory, list->MAC_ADDR, sizeof (list->MAC_ADDR));
+		memory += sizeof (list->MAC_ADDR);
+		value = HTOLE16 (list->NUM_VLANIDS);
+		memcpy (memory, &value, sizeof (value));
+		memory += sizeof (value);
+		for (count = 0; count < list->NUM_VLANIDS; count++)
+		{
+			value = HTOLE16 (list->VLANID [count]);
+			memcpy (memory, &value, sizeof (value));
+			memory += sizeof (value);
+		}
+		list++;
+	}
+	return (memory);
+}
+
 /*
  *   synonym table for options -M and -S;
  */
@@ -500,28 +523,14 @@ static signed AddVLANIDs (struct plc * plc, struct item list [], unsigned items)
 #pragma pack (pop)
 #endif
 
-	struct item * item = request->LIST;
+	uint8_t * item = (uint8_t *)(request->LIST);
 	memset (message, 0, sizeof (* message));
 	EthernetHeader (&request->ethernet, channel->peer, channel->host, channel->type);
 	QualcommHeader (&request->qualcomm, 0, (VS_FORWARD_CONFIG | MMTYPE_REQ));
 	request->MREQUEST = PLCFWD_ADD;
 	request->MVERSION = PLCFWD_VER;
 	request->ITEMS = HTOLE16 (items);
-	while (items--)
-	{
-		unsigned count;
-		memcpy (item->MAC_ADDR, list->MAC_ADDR, sizeof (item->MAC_ADDR));
-		item->NUM_VLANIDS = HTOLE16 (list->NUM_VLANIDS);
-		for (count = 0; count < list->NUM_VLANIDS; count++)
-		{
-			item->VLANID [count] = HTOLE16 (list->VLANID [count]);
-		}
-
-// item++;
-
-		item = (struct item *)(&item->VLANID [count]);
-		list++;
-	}
+	item = EncodeVLANIDs (item, list, items);
 	plc->packetsize = (signed)((uint8_t *)(item) - (uint8_t *)(request));
 	if (SendMME (plc) <= 0)
 	{
@@ -585,28 +594,14 @@ static signed RemoveVLANIDs (struct plc * plc, struct item list [], unsigned ite
 #pragma pack (pop)
 #endif
 
-	struct item * item = request->LIST;
+	uint8_t * item = (uint8_t *)(request->LIST);
 	memset (message, 0, sizeof (* message));
 	EthernetHeader (&request->ethernet, channel->peer, channel->host, channel->type);
 	QualcommHeader (&request->qualcomm, 0, (VS_FORWARD_CONFIG | MMTYPE_REQ));
 	request->MREQUEST = PLCFWD_REM;
 	request->MVERSION = PLCFWD_VER;
 	request->ITEMS = HTOLE16 (items);
-	while (items--)
-	{
-		unsigned count;
-		memcpy (item->MAC_ADDR, list->MAC_ADDR, sizeof (item->MAC_ADDR));
-		item->NUM_VLANIDS = HTOLE16 (list->NUM_VLANIDS);
-		for (count = 0; count < list->NUM_VLANIDS; count++)
-		{
-			item->VLANID [count] = HTOLE16 (list->VLANID [count]);
-		}
-
-// item++;
-
-		item = (struct item *)(&item->VLANID [count]);
-		list++;
-	}
+	item = EncodeVLANIDs (item, list, items);
 	plc->packetsize = (signed)((uint8_t *)(item) - (uint8_t *)(request));
 	if (SendMME (plc) <= 0)
 	{
@@ -1124,4 +1119,3 @@ int main (int argc, char const * argv [])
 	closechannel (&channel);
 	return (0);
 }
-


### PR DESCRIPTION
This PR reworks some access to members in packed structs.